### PR TITLE
Skip empty values

### DIFF
--- a/dist/assets/js/nominatim-ui.js
+++ b/dist/assets/js/nominatim-ui.js
@@ -61,13 +61,13 @@ function map_viewbox_as_string() {
 // *********************************************************
 
 function fetch_from_api(endpoint_name, params, callback) {
+  //
   // `&a=&b=&c=1` => '&c=1'
-
   var param_names = Object.keys(params);
   for (var i = 0; i < param_names.length; i += 1) {
-    var val = param_names[i];
+    var val = params[param_names[i]];
     if (typeof (val) === 'undefined' || val === '' || val === null) {
-      delete param_names[i];
+      delete params[param_names[i]];
     }
   }
 

--- a/dist/deletable.html
+++ b/dist/deletable.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/dist/details.html
+++ b/dist/details.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/dist/polygons.html
+++ b/dist/polygons.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/dist/reverse.html
+++ b/dist/reverse.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/dist/search.html
+++ b/dist/search.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/src/assets/js/base.js
+++ b/src/assets/js/base.js
@@ -61,13 +61,13 @@ function map_viewbox_as_string() {
 // *********************************************************
 
 function fetch_from_api(endpoint_name, params, callback) {
+  //
   // `&a=&b=&c=1` => '&c=1'
-
   var param_names = Object.keys(params);
   for (var i = 0; i < param_names.length; i += 1) {
-    var val = param_names[i];
+    var val = params[param_names[i]];
     if (typeof (val) === 'undefined' || val === '' || val === null) {
-      delete param_names[i];
+      delete params[param_names[i]];
     }
   }
 

--- a/src/layout.html
+++ b/src/layout.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
Even for long URLs like `http://localhost:8000/search.html?q=new+york&street=&city=&county=&state=&country=&postalcode=&polygon_geojson=1&viewbox=` only send `q=new+york&polygon_geojson=1&format=jsonv2` to the API.

Set HTML content type. This avoid the warning "The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range."