### PR TITLE
forward search: use tabs to switch between simple and structured

### DIFF
--- a/dist/assets/css/search.css
+++ b/dist/assets/css/search.css
@@ -7,9 +7,9 @@
   max-width: 500px;
 }
 
-.form-group-simple.hidden,
-.form-group-structured.hidden {
-  display: none;
+.tab-content {
+  border: 1px solid #ddd;
+  border-top: none;
 }
 
 form #q {

--- a/dist/assets/js/nominatim-ui.js
+++ b/dist/assets/js/nominatim-ui.js
@@ -428,20 +428,6 @@ function init_map_on_search_page(is_reverse_search, nominatim_results, request_l
     update_viewbox_field();
   });
 
-  $("input[name='query-selector']").click(function () {
-    var query_val = $("input[name='query-selector']:checked").val();
-    if (query_val === 'simple') {
-      $('div.form-group-simple').removeClass('hidden');
-      $('div.form-group-structured').addClass('hidden');
-      $('.form-group-structured').find('input:text').val('');
-    } else if (query_val === 'structured') {
-      console.log('here');
-      $('div.form-group-simple').addClass('hidden');
-      $('div.form-group-structured').removeClass('hidden');
-      $('.form-group-simple').find('input:text').val('');
-    }
-  });
-
   function get_result_element(position) {
     return $('.result').eq(position);
   }

--- a/dist/search.html
+++ b/dist/search.html
@@ -130,32 +130,41 @@
   </div>
 {{/inline}}
 
-<div class="top-bar" id="structured-query-selector">
-  <div class="search-type-link">
-    <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
-  </div>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="query-selector"
-           id="simple" value="simple" {{#unless hStructured}}checked="checked"{{/unless}}>
-    <label class="form-check-label" for="simple">simple</label>
-  </div>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="query-selector"
-            id="structured" value="structured" {{#if hStructured}}checked="checked"{{/if}}>
-    <label class="form-check-label" for="structured">structured</label>
-  </div>
-
-  <form class="form-inline" role="search" accept-charset="UTF-8" action="">
-    <div class="form-group-simple {{#if hStructured}}hidden{{/if}}">
-      <input id="q"
-             name="q"
-             type="text"
-             class="form-control form-control-sm"
-             placeholder="Search"
-             value="{{sQuery}}" />
+<div class="top-bar">
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+      <a class="nav-link {{#unless hStructured}}active{{/unless}}" data-toggle="tab" href="#simple">simple</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link {{#if hStructured}}active{{/if}}" data-toggle="tab" href="#structured">structured</a>
+    </li>
+    <div class="search-type-link">
+      <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
     </div>
-    <div class="form-group-structured {{#unless hStructured}}hidden{{/unless}}">
-      <div class="form-inline">
+  </ul>
+  <div class="tab-content p-2">
+    <div class="tab-pane {{#unless hStructured}}active{{/unless}}" id="simple" role="tabpanel">
+      <form class="form-inline" role="search" accept-charset="UTF-8" action="">
+        <input id="q"
+               name="q"
+               type="text"
+               class="form-control form-control-sm"
+               placeholder="Search"
+               value="{{sQuery}}" />
+
+        <div class="form-group search-button-group">
+          <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
+          <input type="hidden" name="viewbox" value="{{sViewBox}}" />
+          <div class="form-check form-check-inline">
+            <input type="checkbox" class="form-check-input"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="tab-pane {{#if hStructured}}active{{/if}}" id="structured" role="tabpanel">
+      <form class="form-inline" role="search" accept-charset="UTF-8" action="">
         <input name="street" type="text" class="form-control form-control-sm mr-1"
                placeholder="House number/Street"
                value="{{hStructured.street}}" />
@@ -174,19 +183,20 @@
         <input name="postalcode" type="text" class="form-control form-control-sm mr-1"
                placeholder="Postal Code"
                value="{{hStructured.postalcode}}" />
-      </div>
+
+        <div class="form-group search-button-group">
+          <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
+          <input type="hidden" name="viewbox" value="{{sViewBox}}" />
+          <div class="form-check form-check-inline">
+            <input type="checkbox" class="form-check-input"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
+          </div>
+        </div>
+      </form>
     </div>
-    <div class="form-group search-button-group">
-            <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
-      <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-      <div class="form-check form-check-inline">
-        <input type="checkbox" class="form-check-input"
-               id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-        <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-      </div>
-    </div>
-  </form>
-</div>
+  </div> <!-- /tab-content -->
+</div> <!-- /top-bar -->
 
 <div id="content">
 

--- a/dist/searchpage.hbs
+++ b/dist/searchpage.hbs
@@ -11,32 +11,41 @@
   </div>
 {{/inline}}
 
-<div class="top-bar" id="structured-query-selector">
-  <div class="search-type-link">
-    <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
-  </div>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="query-selector"
-           id="simple" value="simple" {{#unless hStructured}}checked="checked"{{/unless}}>
-    <label class="form-check-label" for="simple">simple</label>
-  </div>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="query-selector"
-            id="structured" value="structured" {{#if hStructured}}checked="checked"{{/if}}>
-    <label class="form-check-label" for="structured">structured</label>
-  </div>
-
-  <form class="form-inline" role="search" accept-charset="UTF-8" action="">
-    <div class="form-group-simple {{#if hStructured}}hidden{{/if}}">
-      <input id="q"
-             name="q"
-             type="text"
-             class="form-control form-control-sm"
-             placeholder="Search"
-             value="{{sQuery}}" />
+<div class="top-bar">
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+      <a class="nav-link {{#unless hStructured}}active{{/unless}}" data-toggle="tab" href="#simple">simple</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link {{#if hStructured}}active{{/if}}" data-toggle="tab" href="#structured">structured</a>
+    </li>
+    <div class="search-type-link">
+      <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
     </div>
-    <div class="form-group-structured {{#unless hStructured}}hidden{{/unless}}">
-      <div class="form-inline">
+  </ul>
+  <div class="tab-content p-2">
+    <div class="tab-pane {{#unless hStructured}}active{{/unless}}" id="simple" role="tabpanel">
+      <form class="form-inline" role="search" accept-charset="UTF-8" action="">
+        <input id="q"
+               name="q"
+               type="text"
+               class="form-control form-control-sm"
+               placeholder="Search"
+               value="{{sQuery}}" />
+
+        <div class="form-group search-button-group">
+          <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
+          <input type="hidden" name="viewbox" value="{{sViewBox}}" />
+          <div class="form-check form-check-inline">
+            <input type="checkbox" class="form-check-input"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="tab-pane {{#if hStructured}}active{{/if}}" id="structured" role="tabpanel">
+      <form class="form-inline" role="search" accept-charset="UTF-8" action="">
         <input name="street" type="text" class="form-control form-control-sm mr-1"
                placeholder="House number/Street"
                value="{{hStructured.street}}" />
@@ -55,19 +64,20 @@
         <input name="postalcode" type="text" class="form-control form-control-sm mr-1"
                placeholder="Postal Code"
                value="{{hStructured.postalcode}}" />
-      </div>
+
+        <div class="form-group search-button-group">
+          <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
+          <input type="hidden" name="viewbox" value="{{sViewBox}}" />
+          <div class="form-check form-check-inline">
+            <input type="checkbox" class="form-check-input"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
+          </div>
+        </div>
+      </form>
     </div>
-    <div class="form-group search-button-group">
-            <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
-      <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-      <div class="form-check form-check-inline">
-        <input type="checkbox" class="form-check-input"
-               id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-        <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-      </div>
-    </div>
-  </form>
-</div>
+  </div> <!-- /tab-content -->
+</div> <!-- /top-bar -->
 
 <div id="content">
 

--- a/src/assets/css/search.css
+++ b/src/assets/css/search.css
@@ -7,9 +7,9 @@
   max-width: 500px;
 }
 
-.form-group-simple.hidden,
-.form-group-structured.hidden {
-  display: none;
+.tab-content {
+  border: 1px solid #ddd;
+  border-top: none;
 }
 
 form #q {

--- a/src/assets/js/searchpage.js
+++ b/src/assets/js/searchpage.js
@@ -170,20 +170,6 @@ function init_map_on_search_page(is_reverse_search, nominatim_results, request_l
     update_viewbox_field();
   });
 
-  $("input[name='query-selector']").click(function () {
-    var query_val = $("input[name='query-selector']:checked").val();
-    if (query_val === 'simple') {
-      $('div.form-group-simple').removeClass('hidden');
-      $('div.form-group-structured').addClass('hidden');
-      $('.form-group-structured').find('input:text').val('');
-    } else if (query_val === 'structured') {
-      console.log('here');
-      $('div.form-group-simple').addClass('hidden');
-      $('div.form-group-structured').removeClass('hidden');
-      $('.form-group-simple').find('input:text').val('');
-    }
-  });
-
   function get_result_element(position) {
     return $('.result').eq(position);
   }

--- a/src/templates/searchpage.hbs
+++ b/src/templates/searchpage.hbs
@@ -11,32 +11,41 @@
   </div>
 {{/inline}}
 
-<div class="top-bar" id="structured-query-selector">
-  <div class="search-type-link">
-    <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
-  </div>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="query-selector"
-           id="simple" value="simple" {{#unless hStructured}}checked="checked"{{/unless}}>
-    <label class="form-check-label" for="simple">simple</label>
-  </div>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="query-selector"
-            id="structured" value="structured" {{#if hStructured}}checked="checked"{{/if}}>
-    <label class="form-check-label" for="structured">structured</label>
-  </div>
-
-  <form class="form-inline" role="search" accept-charset="UTF-8" action="">
-    <div class="form-group-simple {{#if hStructured}}hidden{{/if}}">
-      <input id="q"
-             name="q"
-             type="text"
-             class="form-control form-control-sm"
-             placeholder="Search"
-             value="{{sQuery}}" />
+<div class="top-bar">
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+      <a class="nav-link {{#unless hStructured}}active{{/unless}}" data-toggle="tab" href="#simple">simple</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link {{#if hStructured}}active{{/if}}" data-toggle="tab" href="#structured">structured</a>
+    </li>
+    <div class="search-type-link">
+      <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
     </div>
-    <div class="form-group-structured {{#unless hStructured}}hidden{{/unless}}">
-      <div class="form-inline">
+  </ul>
+  <div class="tab-content p-2">
+    <div class="tab-pane {{#unless hStructured}}active{{/unless}}" id="simple" role="tabpanel">
+      <form class="form-inline" role="search" accept-charset="UTF-8" action="">
+        <input id="q"
+               name="q"
+               type="text"
+               class="form-control form-control-sm"
+               placeholder="Search"
+               value="{{sQuery}}" />
+
+        <div class="form-group search-button-group">
+          <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
+          <input type="hidden" name="viewbox" value="{{sViewBox}}" />
+          <div class="form-check form-check-inline">
+            <input type="checkbox" class="form-check-input"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="tab-pane {{#if hStructured}}active{{/if}}" id="structured" role="tabpanel">
+      <form class="form-inline" role="search" accept-charset="UTF-8" action="">
         <input name="street" type="text" class="form-control form-control-sm mr-1"
                placeholder="House number/Street"
                value="{{hStructured.street}}" />
@@ -55,19 +64,20 @@
         <input name="postalcode" type="text" class="form-control form-control-sm mr-1"
                placeholder="Postal Code"
                value="{{hStructured.postalcode}}" />
-      </div>
+
+        <div class="form-group search-button-group">
+          <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
+          <input type="hidden" name="viewbox" value="{{sViewBox}}" />
+          <div class="form-check form-check-inline">
+            <input type="checkbox" class="form-check-input"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
+          </div>
+        </div>
+      </form>
     </div>
-    <div class="form-group search-button-group">
-            <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
-      <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-      <div class="form-check form-check-inline">
-        <input type="checkbox" class="form-check-input"
-               id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-        <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-      </div>
-    </div>
-  </form>
-</div>
+  </div> <!-- /tab-content -->
+</div> <!-- /top-bar -->
 
 <div id="content">
 


### PR DESCRIPTION
Use tabs and two forms to switch between simple and structured search: Less custom logic and URL after form submission contains less parameter fields.

![image](https://user-images.githubusercontent.com/3727288/85211424-5cda0d00-b349-11ea-8274-476bec34bbb0.png)
