### PR TITLE
Change map to cover complete height of screen

### DIFF
--- a/dist/assets/css/search.css
+++ b/dist/assets/css/search.css
@@ -52,7 +52,7 @@ form #q {
 
 #map-wrapper {
   position: relative;
-  min-height: 700px;
+  height: calc(100vh - 250pt);
   width: 75%;
   padding-right: 20px;
   display: inline-block;
@@ -61,7 +61,6 @@ form #q {
 
 #map {
   height: 100%;
-  min-height: 700px;
   background:#eee;
 }
 

--- a/src/assets/css/search.css
+++ b/src/assets/css/search.css
@@ -52,7 +52,7 @@ form #q {
 
 #map-wrapper {
   position: relative;
-  min-height: 700px;
+  height: calc(100vh - 250pt);
   width: 75%;
   padding-right: 20px;
   display: inline-block;
@@ -61,7 +61,6 @@ form #q {
 
 #map {
   height: 100%;
-  min-height: 700px;
   background:#eee;
 }
 


### PR DESCRIPTION
On hi-res screens the 700px map can become a bit small. Use CSS' calculated lengths to make it always cover the full screen height instead.