### PR TITLE
detail page API response might have addressline with isaddress=false vs inaddress=null

### DIFF
--- a/dist/deletable.html
+++ b/dist/deletable.html
@@ -5,8 +5,8 @@
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="icon" type="image/png" href="/assets/images/favicon-194x194.png" sizes="194x194" />
-  <link rel="icon" type="image/png" href="/assets/images/favicon-16x16.png" sizes="16x16" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-194x194.png" sizes="194x194" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-16x16.png" sizes="16x16" />
 
   <link href="assets/css/leaflet.css" rel="stylesheet" />
   <link href="assets/css/Control.MiniMap.min.css" rel="stylesheet" />
@@ -320,7 +320,7 @@
 <script id="detailspage-template" type="text/x-handlebars-template">
 
 {{#*inline "partial_details_one_row"}}
-  <tr class="{{#unless this.isaddress}}notused{{/unless}}">
+  <tr class="{{#unless bAddressLineUsed}}notused{{/unless}}">
     <td class="name">
       {{#if this.localname}}
         {{this.localname}}
@@ -480,14 +480,14 @@
         <tbody>
           {{#if aPlace.address}}
             {{#each aPlace.address}}
-              {{> partial_details_one_row bDistanceInMeters=false}}
+              {{> partial_details_one_row bDistanceInMeters=false bAddressLineUsed=this.isaddress}}
             {{/each}}
           {{/if}}
 
           {{#if aPlace.linked_places}}
             {{> partial_h2 'Linked Places'}}
             {{#each aPlace.linked_places}}
-              {{> partial_details_one_row bDistanceInMeters=true}}
+              {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
             {{/each}}
           {{/if}}
 
@@ -509,7 +509,7 @@
             {{#each aPlace.hierarchy as |lines type|}}
               {{> partial_h3 type}}
               {{#each lines}}
-                {{> partial_details_one_row bDistanceInMeters=true}}
+                {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
               {{/each}}
             {{/each}}
           {{else}}

--- a/dist/details.html
+++ b/dist/details.html
@@ -5,8 +5,8 @@
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="icon" type="image/png" href="/assets/images/favicon-194x194.png" sizes="194x194" />
-  <link rel="icon" type="image/png" href="/assets/images/favicon-16x16.png" sizes="16x16" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-194x194.png" sizes="194x194" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-16x16.png" sizes="16x16" />
 
   <link href="assets/css/leaflet.css" rel="stylesheet" />
   <link href="assets/css/Control.MiniMap.min.css" rel="stylesheet" />
@@ -320,7 +320,7 @@
 <script id="detailspage-template" type="text/x-handlebars-template">
 
 {{#*inline "partial_details_one_row"}}
-  <tr class="{{#unless this.isaddress}}notused{{/unless}}">
+  <tr class="{{#unless bAddressLineUsed}}notused{{/unless}}">
     <td class="name">
       {{#if this.localname}}
         {{this.localname}}
@@ -480,14 +480,14 @@
         <tbody>
           {{#if aPlace.address}}
             {{#each aPlace.address}}
-              {{> partial_details_one_row bDistanceInMeters=false}}
+              {{> partial_details_one_row bDistanceInMeters=false bAddressLineUsed=this.isaddress}}
             {{/each}}
           {{/if}}
 
           {{#if aPlace.linked_places}}
             {{> partial_h2 'Linked Places'}}
             {{#each aPlace.linked_places}}
-              {{> partial_details_one_row bDistanceInMeters=true}}
+              {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
             {{/each}}
           {{/if}}
 
@@ -509,7 +509,7 @@
             {{#each aPlace.hierarchy as |lines type|}}
               {{> partial_h3 type}}
               {{#each lines}}
-                {{> partial_details_one_row bDistanceInMeters=true}}
+                {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
               {{/each}}
             {{/each}}
           {{else}}

--- a/dist/polygons.html
+++ b/dist/polygons.html
@@ -5,8 +5,8 @@
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="icon" type="image/png" href="/assets/images/favicon-194x194.png" sizes="194x194" />
-  <link rel="icon" type="image/png" href="/assets/images/favicon-16x16.png" sizes="16x16" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-194x194.png" sizes="194x194" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-16x16.png" sizes="16x16" />
 
   <link href="assets/css/leaflet.css" rel="stylesheet" />
   <link href="assets/css/Control.MiniMap.min.css" rel="stylesheet" />
@@ -320,7 +320,7 @@
 <script id="detailspage-template" type="text/x-handlebars-template">
 
 {{#*inline "partial_details_one_row"}}
-  <tr class="{{#unless this.isaddress}}notused{{/unless}}">
+  <tr class="{{#unless bAddressLineUsed}}notused{{/unless}}">
     <td class="name">
       {{#if this.localname}}
         {{this.localname}}
@@ -480,14 +480,14 @@
         <tbody>
           {{#if aPlace.address}}
             {{#each aPlace.address}}
-              {{> partial_details_one_row bDistanceInMeters=false}}
+              {{> partial_details_one_row bDistanceInMeters=false bAddressLineUsed=this.isaddress}}
             {{/each}}
           {{/if}}
 
           {{#if aPlace.linked_places}}
             {{> partial_h2 'Linked Places'}}
             {{#each aPlace.linked_places}}
-              {{> partial_details_one_row bDistanceInMeters=true}}
+              {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
             {{/each}}
           {{/if}}
 
@@ -509,7 +509,7 @@
             {{#each aPlace.hierarchy as |lines type|}}
               {{> partial_h3 type}}
               {{#each lines}}
-                {{> partial_details_one_row bDistanceInMeters=true}}
+                {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
               {{/each}}
             {{/each}}
           {{else}}

--- a/dist/reverse.html
+++ b/dist/reverse.html
@@ -5,8 +5,8 @@
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="icon" type="image/png" href="/assets/images/favicon-194x194.png" sizes="194x194" />
-  <link rel="icon" type="image/png" href="/assets/images/favicon-16x16.png" sizes="16x16" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-194x194.png" sizes="194x194" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-16x16.png" sizes="16x16" />
 
   <link href="assets/css/leaflet.css" rel="stylesheet" />
   <link href="assets/css/Control.MiniMap.min.css" rel="stylesheet" />
@@ -320,7 +320,7 @@
 <script id="detailspage-template" type="text/x-handlebars-template">
 
 {{#*inline "partial_details_one_row"}}
-  <tr class="{{#unless this.isaddress}}notused{{/unless}}">
+  <tr class="{{#unless bAddressLineUsed}}notused{{/unless}}">
     <td class="name">
       {{#if this.localname}}
         {{this.localname}}
@@ -480,14 +480,14 @@
         <tbody>
           {{#if aPlace.address}}
             {{#each aPlace.address}}
-              {{> partial_details_one_row bDistanceInMeters=false}}
+              {{> partial_details_one_row bDistanceInMeters=false bAddressLineUsed=this.isaddress}}
             {{/each}}
           {{/if}}
 
           {{#if aPlace.linked_places}}
             {{> partial_h2 'Linked Places'}}
             {{#each aPlace.linked_places}}
-              {{> partial_details_one_row bDistanceInMeters=true}}
+              {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
             {{/each}}
           {{/if}}
 
@@ -509,7 +509,7 @@
             {{#each aPlace.hierarchy as |lines type|}}
               {{> partial_h3 type}}
               {{#each lines}}
-                {{> partial_details_one_row bDistanceInMeters=true}}
+                {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
               {{/each}}
             {{/each}}
           {{else}}

--- a/dist/search.html
+++ b/dist/search.html
@@ -5,8 +5,8 @@
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="icon" type="image/png" href="/assets/images/favicon-194x194.png" sizes="194x194" />
-  <link rel="icon" type="image/png" href="/assets/images/favicon-16x16.png" sizes="16x16" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-194x194.png" sizes="194x194" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-16x16.png" sizes="16x16" />
 
   <link href="assets/css/leaflet.css" rel="stylesheet" />
   <link href="assets/css/Control.MiniMap.min.css" rel="stylesheet" />
@@ -320,7 +320,7 @@
 <script id="detailspage-template" type="text/x-handlebars-template">
 
 {{#*inline "partial_details_one_row"}}
-  <tr class="{{#unless this.isaddress}}notused{{/unless}}">
+  <tr class="{{#unless bAddressLineUsed}}notused{{/unless}}">
     <td class="name">
       {{#if this.localname}}
         {{this.localname}}
@@ -480,14 +480,14 @@
         <tbody>
           {{#if aPlace.address}}
             {{#each aPlace.address}}
-              {{> partial_details_one_row bDistanceInMeters=false}}
+              {{> partial_details_one_row bDistanceInMeters=false bAddressLineUsed=this.isaddress}}
             {{/each}}
           {{/if}}
 
           {{#if aPlace.linked_places}}
             {{> partial_h2 'Linked Places'}}
             {{#each aPlace.linked_places}}
-              {{> partial_details_one_row bDistanceInMeters=true}}
+              {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
             {{/each}}
           {{/if}}
 
@@ -509,7 +509,7 @@
             {{#each aPlace.hierarchy as |lines type|}}
               {{> partial_h3 type}}
               {{#each lines}}
-                {{> partial_details_one_row bDistanceInMeters=true}}
+                {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
               {{/each}}
             {{/each}}
           {{else}}

--- a/src/layout.html
+++ b/src/layout.html
@@ -5,8 +5,8 @@
   <title>OpenStreetMap Nominatim</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="icon" type="image/png" href="/assets/images/favicon-194x194.png" sizes="194x194" />
-  <link rel="icon" type="image/png" href="/assets/images/favicon-16x16.png" sizes="16x16" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-194x194.png" sizes="194x194" />
+  <link rel="icon" type="image/png" href="assets/images/favicon-16x16.png" sizes="16x16" />
 
   <link href="assets/css/leaflet.css" rel="stylesheet" />
   <link href="assets/css/Control.MiniMap.min.css" rel="stylesheet" />

--- a/src/templates/detailspage.hbs
+++ b/src/templates/detailspage.hbs
@@ -1,6 +1,6 @@
 
 {{#*inline "partial_details_one_row"}}
-  <tr class="{{#unless this.isaddress}}notused{{/unless}}">
+  <tr class="{{#unless bAddressLineUsed}}notused{{/unless}}">
     <td class="name">
       {{#if this.localname}}
         {{this.localname}}
@@ -160,14 +160,14 @@
         <tbody>
           {{#if aPlace.address}}
             {{#each aPlace.address}}
-              {{> partial_details_one_row bDistanceInMeters=false}}
+              {{> partial_details_one_row bDistanceInMeters=false bAddressLineUsed=this.isaddress}}
             {{/each}}
           {{/if}}
 
           {{#if aPlace.linked_places}}
             {{> partial_h2 'Linked Places'}}
             {{#each aPlace.linked_places}}
-              {{> partial_details_one_row bDistanceInMeters=true}}
+              {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
             {{/each}}
           {{/if}}
 
@@ -189,7 +189,7 @@
             {{#each aPlace.hierarchy as |lines type|}}
               {{> partial_h3 type}}
               {{#each lines}}
-                {{> partial_details_one_row bDistanceInMeters=true}}
+                {{> partial_details_one_row bDistanceInMeters=true bAddressLineUsed=true}}
               {{/each}}
             {{/each}}
           {{else}}


### PR DESCRIPTION
Fixes grayed-out address line in the parents and linked-places sections of the detail page. See screenshot.

Includes fix for the favicon URLs.

![image](https://user-images.githubusercontent.com/3727288/91875443-c47ed380-ec7b-11ea-91e1-8215af834481.png)
