### PR TITLE
Add interface for setting advanced search options

### DIFF
--- a/dist/assets/css/search.css
+++ b/dist/assets/css/search.css
@@ -10,6 +10,8 @@
 .tab-content {
   border: 1px solid #ddd;
   border-top: none;
+  display: flex;
+  align-items: baseline
 }
 
 form #q {
@@ -155,4 +157,18 @@ form #q {
 
 label {
   font-weight: normal;
+}
+
+#searchAdvancedOptionsContent {
+  display: flex;
+  flex-direction: column;
+  padding: 0 10px
+}
+
+#searchAdvancedOptionsContent label {
+  padding: 0 3px;
+}
+
+#searchAdvancedOptionsContent span {
+  padding: 4px 10px;
 }

--- a/dist/assets/js/nominatim-ui.js
+++ b/dist/assets/js/nominatim-ui.js
@@ -331,7 +331,7 @@ function display_map_position(mouse_lat_lng) {
   };
   $('#switch-to-reverse').attr('href', 'reverse.html?' + $.param(reverse_params));
 
-  $('input#use_viewbox').trigger('change');
+  $('input.api-param-setting').trigger('change');
 }
 
 function init_map_on_search_page(is_reverse_search, nominatim_results, request_lat,
@@ -455,6 +455,23 @@ function init_map_on_search_page(is_reverse_search, nominatim_results, request_l
   $('input#use_viewbox').on('change', function () {
     update_viewbox_field();
   });
+
+  $('input#option_bounded').on('change', function () {
+    $('input[name=bounded]')
+      .val($('input#option_bounded')
+        .prop('checked') ? '1' : '');
+  });
+
+  $('input#option_dedupe').on('change', function () {
+    $('input[name=dedupe]')
+      .val($('input#option_dedupe')
+        .prop('checked') ? '' : '0');
+  });
+
+  $('input[data-api-param]').on('change', function (e) {
+    $('input[name=' + $(e.target).data('api-param') + ']').val(e.target.value);
+  });
+
 
   function get_result_element(position) {
     return $('.result').eq(position);
@@ -667,6 +684,12 @@ function search_page_load() {
       postalcode: search_params.get('postalcode'),
       polygon_geojson: get_config_value('Search_AreaPolygons', false) ? 1 : 0,
       viewbox: search_params.get('viewbox'),
+      bounded: search_params.get('bounded'),
+      dedupe: search_params.get('dedupe'),
+      'accept-language': search_params.get('accept-language'),
+      countrycodes: search_params.get('countrycodes'),
+      limit: search_params.get('limit'),
+      polygon_threshold: search_params.get('polygon_threshold'),
       exclude_place_ids: search_params.get('exclude_place_ids'),
       format: 'jsonv2'
     };
@@ -674,6 +697,12 @@ function search_page_load() {
     context = {
       sQuery: api_request_params.q,
       sViewBox: search_params.get('viewbox'),
+      sBounded: search_params.get('bounded'),
+      sDedupe: search_params.get('dedupe'),
+      sLang: search_params.get('accept-language'),
+      sCCode: search_params.get('countrycodes'),
+      sLimit: search_params.get('limit'),
+      sPolyThreshold: search_params.get('polygon_threshold'),
       env: {}
     };
 

--- a/dist/deletable.html
+++ b/dist/deletable.html
@@ -157,11 +157,12 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{sDedupe}}" />
+          <input type="hidden" name="bounded" value="{{sBounded}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
     </div>
@@ -189,13 +190,45 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{#unless sDedupe}}0{{/unless}}" />
+          <input type="hidden" name="bounded" value="{{#if sBounded}}1{{/if}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
+    </div>
+    <!-- Additional options -->
+    <a class="btn btn-outline-secondary btn-sm" data-toggle="collapse" data-target="#searchAdvancedOptions" role="button" aria-expanded="false" aria-controls="collapseAdvancedOptions">
+      Advanced options
+    </a>
+    <div class="collapse" id="searchAdvancedOptions">
+      <div id="searchAdvancedOptionsContent">
+          <div class="form-check form-check-inline">
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
+            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="limit" id="option_limit" size="5" min="1" max="50" value="{{sLimit}}"></span>
+            <span><label class="form-check-label" for="option_polygon_threashold">Polygon simplification: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="polygon_threshold" id="option_polygon_threshold" size="5" min="0.0" step="0.01" value="{{sPolyThreshold}}"></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="accept_lang">Languages: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <span><label class="form-check-label" for="option_ccode">Countries: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+          </div>
+       </div>
     </div>
   </div> <!-- /tab-content -->
 </div> <!-- /top-bar -->

--- a/dist/deletable.html
+++ b/dist/deletable.html
@@ -211,10 +211,10 @@
             <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <label class="form-check-label" for="option_bounded">bounded to viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
-            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+            <label class="form-check-label" for="option_dedupe">deduplicate results</label></span>
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
@@ -224,9 +224,9 @@
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="accept_lang">Languages: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <input type="text" placeholder="e.g. en,zh-Hant" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
             <span><label class="form-check-label" for="option_ccode">Countries: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+            <input type="text" placeholder="e.g. de,gb" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
           </div>
        </div>
     </div>

--- a/dist/details.html
+++ b/dist/details.html
@@ -157,11 +157,12 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{sDedupe}}" />
+          <input type="hidden" name="bounded" value="{{sBounded}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
     </div>
@@ -189,13 +190,45 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{#unless sDedupe}}0{{/unless}}" />
+          <input type="hidden" name="bounded" value="{{#if sBounded}}1{{/if}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
+    </div>
+    <!-- Additional options -->
+    <a class="btn btn-outline-secondary btn-sm" data-toggle="collapse" data-target="#searchAdvancedOptions" role="button" aria-expanded="false" aria-controls="collapseAdvancedOptions">
+      Advanced options
+    </a>
+    <div class="collapse" id="searchAdvancedOptions">
+      <div id="searchAdvancedOptionsContent">
+          <div class="form-check form-check-inline">
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
+            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="limit" id="option_limit" size="5" min="1" max="50" value="{{sLimit}}"></span>
+            <span><label class="form-check-label" for="option_polygon_threashold">Polygon simplification: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="polygon_threshold" id="option_polygon_threshold" size="5" min="0.0" step="0.01" value="{{sPolyThreshold}}"></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="accept_lang">Languages: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <span><label class="form-check-label" for="option_ccode">Countries: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+          </div>
+       </div>
     </div>
   </div> <!-- /tab-content -->
 </div> <!-- /top-bar -->

--- a/dist/details.html
+++ b/dist/details.html
@@ -211,10 +211,10 @@
             <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <label class="form-check-label" for="option_bounded">bounded to viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
-            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+            <label class="form-check-label" for="option_dedupe">deduplicate results</label></span>
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
@@ -224,9 +224,9 @@
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="accept_lang">Languages: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <input type="text" placeholder="e.g. en,zh-Hant" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
             <span><label class="form-check-label" for="option_ccode">Countries: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+            <input type="text" placeholder="e.g. de,gb" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
           </div>
        </div>
     </div>

--- a/dist/polygons.html
+++ b/dist/polygons.html
@@ -157,11 +157,12 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{sDedupe}}" />
+          <input type="hidden" name="bounded" value="{{sBounded}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
     </div>
@@ -189,13 +190,45 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{#unless sDedupe}}0{{/unless}}" />
+          <input type="hidden" name="bounded" value="{{#if sBounded}}1{{/if}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
+    </div>
+    <!-- Additional options -->
+    <a class="btn btn-outline-secondary btn-sm" data-toggle="collapse" data-target="#searchAdvancedOptions" role="button" aria-expanded="false" aria-controls="collapseAdvancedOptions">
+      Advanced options
+    </a>
+    <div class="collapse" id="searchAdvancedOptions">
+      <div id="searchAdvancedOptionsContent">
+          <div class="form-check form-check-inline">
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
+            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="limit" id="option_limit" size="5" min="1" max="50" value="{{sLimit}}"></span>
+            <span><label class="form-check-label" for="option_polygon_threashold">Polygon simplification: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="polygon_threshold" id="option_polygon_threshold" size="5" min="0.0" step="0.01" value="{{sPolyThreshold}}"></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="accept_lang">Languages: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <span><label class="form-check-label" for="option_ccode">Countries: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+          </div>
+       </div>
     </div>
   </div> <!-- /tab-content -->
 </div> <!-- /top-bar -->

--- a/dist/polygons.html
+++ b/dist/polygons.html
@@ -211,10 +211,10 @@
             <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <label class="form-check-label" for="option_bounded">bounded to viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
-            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+            <label class="form-check-label" for="option_dedupe">deduplicate results</label></span>
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
@@ -224,9 +224,9 @@
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="accept_lang">Languages: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <input type="text" placeholder="e.g. en,zh-Hant" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
             <span><label class="form-check-label" for="option_ccode">Countries: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+            <input type="text" placeholder="e.g. de,gb" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
           </div>
        </div>
     </div>

--- a/dist/reverse.html
+++ b/dist/reverse.html
@@ -157,11 +157,12 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{sDedupe}}" />
+          <input type="hidden" name="bounded" value="{{sBounded}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
     </div>
@@ -189,13 +190,45 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{#unless sDedupe}}0{{/unless}}" />
+          <input type="hidden" name="bounded" value="{{#if sBounded}}1{{/if}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
+    </div>
+    <!-- Additional options -->
+    <a class="btn btn-outline-secondary btn-sm" data-toggle="collapse" data-target="#searchAdvancedOptions" role="button" aria-expanded="false" aria-controls="collapseAdvancedOptions">
+      Advanced options
+    </a>
+    <div class="collapse" id="searchAdvancedOptions">
+      <div id="searchAdvancedOptionsContent">
+          <div class="form-check form-check-inline">
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
+            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="limit" id="option_limit" size="5" min="1" max="50" value="{{sLimit}}"></span>
+            <span><label class="form-check-label" for="option_polygon_threashold">Polygon simplification: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="polygon_threshold" id="option_polygon_threshold" size="5" min="0.0" step="0.01" value="{{sPolyThreshold}}"></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="accept_lang">Languages: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <span><label class="form-check-label" for="option_ccode">Countries: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+          </div>
+       </div>
     </div>
   </div> <!-- /tab-content -->
 </div> <!-- /top-bar -->

--- a/dist/reverse.html
+++ b/dist/reverse.html
@@ -211,10 +211,10 @@
             <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <label class="form-check-label" for="option_bounded">bounded to viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
-            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+            <label class="form-check-label" for="option_dedupe">deduplicate results</label></span>
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
@@ -224,9 +224,9 @@
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="accept_lang">Languages: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <input type="text" placeholder="e.g. en,zh-Hant" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
             <span><label class="form-check-label" for="option_ccode">Countries: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+            <input type="text" placeholder="e.g. de,gb" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
           </div>
        </div>
     </div>

--- a/dist/search.html
+++ b/dist/search.html
@@ -157,11 +157,12 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{sDedupe}}" />
+          <input type="hidden" name="bounded" value="{{sBounded}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
     </div>
@@ -189,13 +190,45 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{#unless sDedupe}}0{{/unless}}" />
+          <input type="hidden" name="bounded" value="{{#if sBounded}}1{{/if}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
+    </div>
+    <!-- Additional options -->
+    <a class="btn btn-outline-secondary btn-sm" data-toggle="collapse" data-target="#searchAdvancedOptions" role="button" aria-expanded="false" aria-controls="collapseAdvancedOptions">
+      Advanced options
+    </a>
+    <div class="collapse" id="searchAdvancedOptions">
+      <div id="searchAdvancedOptionsContent">
+          <div class="form-check form-check-inline">
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
+            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="limit" id="option_limit" size="5" min="1" max="50" value="{{sLimit}}"></span>
+            <span><label class="form-check-label" for="option_polygon_threashold">Polygon simplification: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="polygon_threshold" id="option_polygon_threshold" size="5" min="0.0" step="0.01" value="{{sPolyThreshold}}"></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="accept_lang">Languages: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <span><label class="form-check-label" for="option_ccode">Countries: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+          </div>
+       </div>
     </div>
   </div> <!-- /tab-content -->
 </div> <!-- /top-bar -->

--- a/dist/search.html
+++ b/dist/search.html
@@ -211,10 +211,10 @@
             <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <label class="form-check-label" for="option_bounded">bounded to viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
-            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+            <label class="form-check-label" for="option_dedupe">deduplicate results</label></span>
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
@@ -224,9 +224,9 @@
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="accept_lang">Languages: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <input type="text" placeholder="e.g. en,zh-Hant" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
             <span><label class="form-check-label" for="option_ccode">Countries: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+            <input type="text" placeholder="e.g. de,gb" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
           </div>
        </div>
     </div>

--- a/src/assets/css/search.css
+++ b/src/assets/css/search.css
@@ -10,6 +10,8 @@
 .tab-content {
   border: 1px solid #ddd;
   border-top: none;
+  display: flex;
+  align-items: baseline
 }
 
 form #q {
@@ -155,4 +157,18 @@ form #q {
 
 label {
   font-weight: normal;
+}
+
+#searchAdvancedOptionsContent {
+  display: flex;
+  flex-direction: column;
+  padding: 0 10px
+}
+
+#searchAdvancedOptionsContent label {
+  padding: 0 3px;
+}
+
+#searchAdvancedOptionsContent span {
+  padding: 4px 10px;
 }

--- a/src/assets/js/searchpage.js
+++ b/src/assets/js/searchpage.js
@@ -45,7 +45,7 @@ function display_map_position(mouse_lat_lng) {
   };
   $('#switch-to-reverse').attr('href', 'reverse.html?' + $.param(reverse_params));
 
-  $('input#use_viewbox').trigger('change');
+  $('input.api-param-setting').trigger('change');
 }
 
 function init_map_on_search_page(is_reverse_search, nominatim_results, request_lat,
@@ -169,6 +169,23 @@ function init_map_on_search_page(is_reverse_search, nominatim_results, request_l
   $('input#use_viewbox').on('change', function () {
     update_viewbox_field();
   });
+
+  $('input#option_bounded').on('change', function () {
+    $('input[name=bounded]')
+      .val($('input#option_bounded')
+        .prop('checked') ? '1' : '');
+  });
+
+  $('input#option_dedupe').on('change', function () {
+    $('input[name=dedupe]')
+      .val($('input#option_dedupe')
+        .prop('checked') ? '' : '0');
+  });
+
+  $('input[data-api-param]').on('change', function (e) {
+    $('input[name=' + $(e.target).data('api-param') + ']').val(e.target.value);
+  });
+
 
   function get_result_element(position) {
     return $('.result').eq(position);
@@ -381,6 +398,12 @@ function search_page_load() {
       postalcode: search_params.get('postalcode'),
       polygon_geojson: get_config_value('Search_AreaPolygons', false) ? 1 : 0,
       viewbox: search_params.get('viewbox'),
+      bounded: search_params.get('bounded'),
+      dedupe: search_params.get('dedupe'),
+      'accept-language': search_params.get('accept-language'),
+      countrycodes: search_params.get('countrycodes'),
+      limit: search_params.get('limit'),
+      polygon_threshold: search_params.get('polygon_threshold'),
       exclude_place_ids: search_params.get('exclude_place_ids'),
       format: 'jsonv2'
     };
@@ -388,6 +411,12 @@ function search_page_load() {
     context = {
       sQuery: api_request_params.q,
       sViewBox: search_params.get('viewbox'),
+      sBounded: search_params.get('bounded'),
+      sDedupe: search_params.get('dedupe'),
+      sLang: search_params.get('accept-language'),
+      sCCode: search_params.get('countrycodes'),
+      sLimit: search_params.get('limit'),
+      sPolyThreshold: search_params.get('polygon_threshold'),
       env: {}
     };
 

--- a/src/templates/searchpage.hbs
+++ b/src/templates/searchpage.hbs
@@ -90,10 +90,10 @@
             <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <label class="form-check-label" for="option_bounded">bounded to viewbox</label></span>
             <span><input type="checkbox" class="form-check-input api-param-setting"
                    id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
-            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+            <label class="form-check-label" for="option_dedupe">deduplicate results</label></span>
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
@@ -103,9 +103,9 @@
           </div>
           <div class="form-check form-check-inline">
             <span><label class="form-check-label" for="accept_lang">Languages: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <input type="text" placeholder="e.g. en,zh-Hant" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
             <span><label class="form-check-label" for="option_ccode">Countries: </label>
-            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+            <input type="text" placeholder="e.g. de,gb" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
           </div>
        </div>
     </div>

--- a/src/templates/searchpage.hbs
+++ b/src/templates/searchpage.hbs
@@ -36,11 +36,12 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{sDedupe}}" />
+          <input type="hidden" name="bounded" value="{{sBounded}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
     </div>
@@ -68,13 +69,45 @@
         <div class="form-group search-button-group">
           <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>
           <input type="hidden" name="viewbox" value="{{sViewBox}}" />
-          <div class="form-check form-check-inline">
-            <input type="checkbox" class="form-check-input"
-                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
-            <label class="form-check-label" for="use_viewbox">apply viewbox</label>
-          </div>
+          <input type="hidden" name="dedupe" value="{{#unless sDedupe}}0{{/unless}}" />
+          <input type="hidden" name="bounded" value="{{#if sBounded}}1{{/if}}" />
+          <input type="hidden" name="accept-language" value="{{sLang}}" />
+          <input type="hidden" name="countrycodes" value="{{sCCode}}" />
+          <input type="hidden" name="limit" value="{{sLimit}}" />
+          <input type="hidden" name="polygon_threshold" value="{{sPolyThreshold}}" />
         </div>
       </form>
+    </div>
+    <!-- Additional options -->
+    <a class="btn btn-outline-secondary btn-sm" data-toggle="collapse" data-target="#searchAdvancedOptions" role="button" aria-expanded="false" aria-controls="collapseAdvancedOptions">
+      Advanced options
+    </a>
+    <div class="collapse" id="searchAdvancedOptions">
+      <div id="searchAdvancedOptionsContent">
+          <div class="form-check form-check-inline">
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="use_viewbox" {{#if sViewBox}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="use_viewbox">apply viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_bounded" {{#if sBounded}}checked="checked"{{/if}}>
+            <label class="form-check-label" for="options_bounded">bounded to viewbox</label></span>
+            <span><input type="checkbox" class="form-check-input api-param-setting"
+                   id="option_dedupe" {{#unless sDedupe}}checked="checked"{{/unless}}>
+            <label class="form-check-label" for="options_dedupe">deduplicate results</label></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="option_limit">Maximum number of results: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="limit" id="option_limit" size="5" min="1" max="50" value="{{sLimit}}"></span>
+            <span><label class="form-check-label" for="option_polygon_threashold">Polygon simplification: </label>
+            <input type="number" class="form-check-input api-param-setting" data-api-param="polygon_threshold" id="option_polygon_threshold" size="5" min="0.0" step="0.01" value="{{sPolyThreshold}}"></span>
+          </div>
+          <div class="form-check form-check-inline">
+            <span><label class="form-check-label" for="accept_lang">Languages: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="accept-language" id="accept_lang" size="15" value="{{sLang}}"></span>
+            <span><label class="form-check-label" for="option_ccode">Countries: </label>
+            <input type="text" class="form-check-input api-param-setting" data-api-param="countrycodes" id="option_ccode" size="15" value="{{sCCode}}"></span>
+          </div>
+       </div>
     </div>
   </div> <!-- /tab-content -->
 </div> <!-- /top-bar -->


### PR DESCRIPTION
This adds an 'Advanced Options' view to the search page. It allows to toggle some of the options that might be useful for debugging. The whole thing is hidden behind a collapsible, so that the options are normally not visible.

First half of #34. I have to do the same for reverse but wanted feedback first, if the approach is a good one. I'm interested in feedback for UI and code.

