### PR TITLE
navigation link to -search by id-

### DIFF
--- a/dist/deletable.html
+++ b/dist/deletable.html
@@ -140,6 +140,7 @@
       <a class="nav-link {{#if hStructured}}active{{/if}}" data-toggle="tab" href="#structured">structured</a>
     </li>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
     </div>
   </ul>
@@ -290,6 +291,7 @@
       </button>
     </div>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a href="search.html">forward search</a>
     </div>
   </form>

--- a/dist/details.html
+++ b/dist/details.html
@@ -140,6 +140,7 @@
       <a class="nav-link {{#if hStructured}}active{{/if}}" data-toggle="tab" href="#structured">structured</a>
     </li>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
     </div>
   </ul>
@@ -290,6 +291,7 @@
       </button>
     </div>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a href="search.html">forward search</a>
     </div>
   </form>

--- a/dist/polygons.html
+++ b/dist/polygons.html
@@ -140,6 +140,7 @@
       <a class="nav-link {{#if hStructured}}active{{/if}}" data-toggle="tab" href="#structured">structured</a>
     </li>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
     </div>
   </ul>
@@ -290,6 +291,7 @@
       </button>
     </div>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a href="search.html">forward search</a>
     </div>
   </form>

--- a/dist/reverse.html
+++ b/dist/reverse.html
@@ -140,6 +140,7 @@
       <a class="nav-link {{#if hStructured}}active{{/if}}" data-toggle="tab" href="#structured">structured</a>
     </li>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
     </div>
   </ul>
@@ -290,6 +291,7 @@
       </button>
     </div>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a href="search.html">forward search</a>
     </div>
   </form>

--- a/dist/search.html
+++ b/dist/search.html
@@ -140,6 +140,7 @@
       <a class="nav-link {{#if hStructured}}active{{/if}}" data-toggle="tab" href="#structured">structured</a>
     </li>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
     </div>
   </ul>
@@ -290,6 +291,7 @@
       </button>
     </div>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a href="search.html">forward search</a>
     </div>
   </form>

--- a/src/templates/reversepage.hbs
+++ b/src/templates/reversepage.hbs
@@ -37,6 +37,7 @@
       </button>
     </div>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a href="search.html">forward search</a>
     </div>
   </form>

--- a/src/templates/searchpage.hbs
+++ b/src/templates/searchpage.hbs
@@ -19,6 +19,7 @@
       <a class="nav-link {{#if hStructured}}active{{/if}}" data-toggle="tab" href="#structured">structured</a>
     </li>
     <div class="search-type-link">
+      <a href="details.html" class="mr-2">search by id</a>
       <a id="switch-to-reverse" href="/reverse.html">reverse search</a>
     </div>
   </ul>


### PR DESCRIPTION
Fixes https://github.com/osm-search/nominatim-ui/issues/39

We should probably make all 4 types (plus autosuggest/suggestions in the future) tabs or consistent. Until then, and since https://github.com/osm-search/nominatim-ui/pull/38 already touches the name lines of HTML, a simple link will suffice.

![image](https://user-images.githubusercontent.com/3727288/97478855-d1edcc80-1951-11eb-9cde-a379a67fcbc4.png)
