### PR TITLE
Minor adaptions of details view to new address rank use

### DIFF
--- a/dist/deletable.html
+++ b/dist/deletable.html
@@ -426,8 +426,12 @@
           <td>{{aPlace.admin_level}}</td>
         </tr>
         <tr>
-          <td>Rank</td>
-          <td>{{formatSearchRank aPlace.rank_search}}</td>
+          <td>Search Rank</td>
+          <td>{{aPlace.rank_search}}</td>
+        </tr>
+        <tr>
+          <td>Address Rank</td>
+          <td>{{aPlace.rank_address}} ({{formatAddressRank aPlace.rank_address}})</td>
         </tr>
         {{#if aPlace.calculated_importance}}
           <tr>

--- a/dist/deletable.html
+++ b/dist/deletable.html
@@ -421,10 +421,12 @@
           <td>Last Updated</td>
           <td>{{aPlace.indexed_date}}</td>
         </tr>
+        {{#if (isAdminBoundary aPlace) }}
         <tr>
           <td>Admin Level</td>
           <td>{{aPlace.admin_level}}</td>
         </tr>
+        {{/if}}
         <tr>
           <td>Search Rank</td>
           <td>{{aPlace.rank_search}}</td>

--- a/dist/details.html
+++ b/dist/details.html
@@ -426,8 +426,12 @@
           <td>{{aPlace.admin_level}}</td>
         </tr>
         <tr>
-          <td>Rank</td>
-          <td>{{formatSearchRank aPlace.rank_search}}</td>
+          <td>Search Rank</td>
+          <td>{{aPlace.rank_search}}</td>
+        </tr>
+        <tr>
+          <td>Address Rank</td>
+          <td>{{aPlace.rank_address}} ({{formatAddressRank aPlace.rank_address}})</td>
         </tr>
         {{#if aPlace.calculated_importance}}
           <tr>

--- a/dist/details.html
+++ b/dist/details.html
@@ -421,10 +421,12 @@
           <td>Last Updated</td>
           <td>{{aPlace.indexed_date}}</td>
         </tr>
+        {{#if (isAdminBoundary aPlace) }}
         <tr>
           <td>Admin Level</td>
           <td>{{aPlace.admin_level}}</td>
         </tr>
+        {{/if}}
         <tr>
           <td>Search Rank</td>
           <td>{{aPlace.rank_search}}</td>

--- a/dist/handlebar_helpers.js
+++ b/dist/handlebar_helpers.js
@@ -251,6 +251,9 @@ Handlebars.registerHelper({
     if (iRank <= 30) return 'house / building';
     return 'other';
   },
+  isAdminBoundary: function (aPlace) {
+    return aPlace.category === 'boundary' && aPlace.type === 'administrative';
+  },
   tooManyHierarchyLinesWarning: function (aPlace) {
     if (!aPlace.hierarchy) return '';
 

--- a/dist/handlebar_helpers.js
+++ b/dist/handlebar_helpers.js
@@ -233,28 +233,23 @@ Handlebars.registerHelper({
     }
     return '';
   },
-  formatSearchRank: function (iRank) {
-    // same as
-    // https://github.com/osm-search/Nominatim/blob/master/sql/functions.sql
-    // get_searchrank_label()
-
-    if (iRank < 2) return 'continent';
-    if (iRank < 4) return 'sea';
-    if (iRank < 8) return 'country';
-    if (iRank < 12) return 'state';
-    if (iRank < 16) return 'county';
-    if (iRank === 16) return 'city';
-    if (iRank === 17) return 'town / island';
-    if (iRank === 18) return 'village / hamlet';
-    if (iRank === 20) return 'suburb';
-    if (iRank === 21) return 'postcode area';
-    if (iRank === 22) return 'croft / farm / locality / islet';
-    if (iRank === 23) return 'postcode area';
-    if (iRank === 25) return 'postcode point';
-    if (iRank === 26) return 'street / major landmark';
+  formatAddressRank: function (iRank) {
+    if (iRank < 4) return 'other';
+    if (iRank < 6) return 'country';
+    if (iRank < 8) return 'region';
+    if (iRank < 10) return 'state';
+    if (iRank < 12) return 'state district';
+    if (iRank < 14) return 'county';
+    if (iRank < 16) return 'municipality';
+    if (iRank < 18) return 'city / town / village';
+    if (iRank < 20) return 'city / village district';
+    if (iRank < 22) return 'suburb / hamlet';
+    if (iRank < 24) return 'neighbourhood';
+    if (iRank < 26) return 'city block / square';
+    if (iRank === 26) return 'major street';
     if (iRank === 27) return 'minory street / path';
-    if (iRank === 28) return 'house / building';
-    return 'other: ' + iRank;
+    if (iRank <= 30) return 'house / building';
+    return 'other';
   },
   tooManyHierarchyLinesWarning: function (aPlace) {
     if (!aPlace.hierarchy) return '';

--- a/dist/polygons.html
+++ b/dist/polygons.html
@@ -426,8 +426,12 @@
           <td>{{aPlace.admin_level}}</td>
         </tr>
         <tr>
-          <td>Rank</td>
-          <td>{{formatSearchRank aPlace.rank_search}}</td>
+          <td>Search Rank</td>
+          <td>{{aPlace.rank_search}}</td>
+        </tr>
+        <tr>
+          <td>Address Rank</td>
+          <td>{{aPlace.rank_address}} ({{formatAddressRank aPlace.rank_address}})</td>
         </tr>
         {{#if aPlace.calculated_importance}}
           <tr>

--- a/dist/polygons.html
+++ b/dist/polygons.html
@@ -421,10 +421,12 @@
           <td>Last Updated</td>
           <td>{{aPlace.indexed_date}}</td>
         </tr>
+        {{#if (isAdminBoundary aPlace) }}
         <tr>
           <td>Admin Level</td>
           <td>{{aPlace.admin_level}}</td>
         </tr>
+        {{/if}}
         <tr>
           <td>Search Rank</td>
           <td>{{aPlace.rank_search}}</td>

--- a/dist/reverse.html
+++ b/dist/reverse.html
@@ -426,8 +426,12 @@
           <td>{{aPlace.admin_level}}</td>
         </tr>
         <tr>
-          <td>Rank</td>
-          <td>{{formatSearchRank aPlace.rank_search}}</td>
+          <td>Search Rank</td>
+          <td>{{aPlace.rank_search}}</td>
+        </tr>
+        <tr>
+          <td>Address Rank</td>
+          <td>{{aPlace.rank_address}} ({{formatAddressRank aPlace.rank_address}})</td>
         </tr>
         {{#if aPlace.calculated_importance}}
           <tr>

--- a/dist/reverse.html
+++ b/dist/reverse.html
@@ -421,10 +421,12 @@
           <td>Last Updated</td>
           <td>{{aPlace.indexed_date}}</td>
         </tr>
+        {{#if (isAdminBoundary aPlace) }}
         <tr>
           <td>Admin Level</td>
           <td>{{aPlace.admin_level}}</td>
         </tr>
+        {{/if}}
         <tr>
           <td>Search Rank</td>
           <td>{{aPlace.rank_search}}</td>

--- a/dist/search.html
+++ b/dist/search.html
@@ -426,8 +426,12 @@
           <td>{{aPlace.admin_level}}</td>
         </tr>
         <tr>
-          <td>Rank</td>
-          <td>{{formatSearchRank aPlace.rank_search}}</td>
+          <td>Search Rank</td>
+          <td>{{aPlace.rank_search}}</td>
+        </tr>
+        <tr>
+          <td>Address Rank</td>
+          <td>{{aPlace.rank_address}} ({{formatAddressRank aPlace.rank_address}})</td>
         </tr>
         {{#if aPlace.calculated_importance}}
           <tr>

--- a/dist/search.html
+++ b/dist/search.html
@@ -421,10 +421,12 @@
           <td>Last Updated</td>
           <td>{{aPlace.indexed_date}}</td>
         </tr>
+        {{#if (isAdminBoundary aPlace) }}
         <tr>
           <td>Admin Level</td>
           <td>{{aPlace.admin_level}}</td>
         </tr>
+        {{/if}}
         <tr>
           <td>Search Rank</td>
           <td>{{aPlace.rank_search}}</td>

--- a/src/handlebar_helpers.js
+++ b/src/handlebar_helpers.js
@@ -251,6 +251,9 @@ Handlebars.registerHelper({
     if (iRank <= 30) return 'house / building';
     return 'other';
   },
+  isAdminBoundary: function (aPlace) {
+    return aPlace.category === 'boundary' && aPlace.type === 'administrative';
+  },
   tooManyHierarchyLinesWarning: function (aPlace) {
     if (!aPlace.hierarchy) return '';
 

--- a/src/handlebar_helpers.js
+++ b/src/handlebar_helpers.js
@@ -233,28 +233,23 @@ Handlebars.registerHelper({
     }
     return '';
   },
-  formatSearchRank: function (iRank) {
-    // same as
-    // https://github.com/osm-search/Nominatim/blob/master/sql/functions.sql
-    // get_searchrank_label()
-
-    if (iRank < 2) return 'continent';
-    if (iRank < 4) return 'sea';
-    if (iRank < 8) return 'country';
-    if (iRank < 12) return 'state';
-    if (iRank < 16) return 'county';
-    if (iRank === 16) return 'city';
-    if (iRank === 17) return 'town / island';
-    if (iRank === 18) return 'village / hamlet';
-    if (iRank === 20) return 'suburb';
-    if (iRank === 21) return 'postcode area';
-    if (iRank === 22) return 'croft / farm / locality / islet';
-    if (iRank === 23) return 'postcode area';
-    if (iRank === 25) return 'postcode point';
-    if (iRank === 26) return 'street / major landmark';
+  formatAddressRank: function (iRank) {
+    if (iRank < 4) return 'other';
+    if (iRank < 6) return 'country';
+    if (iRank < 8) return 'region';
+    if (iRank < 10) return 'state';
+    if (iRank < 12) return 'state district';
+    if (iRank < 14) return 'county';
+    if (iRank < 16) return 'municipality';
+    if (iRank < 18) return 'city / town / village';
+    if (iRank < 20) return 'city / village district';
+    if (iRank < 22) return 'suburb / hamlet';
+    if (iRank < 24) return 'neighbourhood';
+    if (iRank < 26) return 'city block / square';
+    if (iRank === 26) return 'major street';
     if (iRank === 27) return 'minory street / path';
-    if (iRank === 28) return 'house / building';
-    return 'other: ' + iRank;
+    if (iRank <= 30) return 'house / building';
+    return 'other';
   },
   tooManyHierarchyLinesWarning: function (aPlace) {
     if (!aPlace.hierarchy) return '';

--- a/src/templates/detailspage.hbs
+++ b/src/templates/detailspage.hbs
@@ -73,8 +73,12 @@
           <td>{{aPlace.admin_level}}</td>
         </tr>
         <tr>
-          <td>Rank</td>
-          <td>{{formatSearchRank aPlace.rank_search}}</td>
+          <td>Search Rank</td>
+          <td>{{aPlace.rank_search}}</td>
+        </tr>
+        <tr>
+          <td>Address Rank</td>
+          <td>{{aPlace.rank_address}} ({{formatAddressRank aPlace.rank_address}})</td>
         </tr>
         {{#if aPlace.calculated_importance}}
           <tr>

--- a/src/templates/detailspage.hbs
+++ b/src/templates/detailspage.hbs
@@ -68,10 +68,12 @@
           <td>Last Updated</td>
           <td>{{aPlace.indexed_date}}</td>
         </tr>
+        {{#if (isAdminBoundary aPlace) }}
         <tr>
           <td>Admin Level</td>
           <td>{{aPlace.admin_level}}</td>
         </tr>
+        {{/if}}
         <tr>
           <td>Search Rank</td>
           <td>{{aPlace.rank_search}}</td>


### PR DESCRIPTION
Split rank display into search and address rank. As the address rank is the one that these days has a fixed relation to place types, move the descriptive rank term there and use only a number for search rank.

Display admin levels only for administrative boundaries. The value does not have a meaning for other objects.