### PR TITLE
Handle all page changes via page store

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <!-- deal with back-button and other user action -->
-<svelte:window on:popstate={refresh_page} />
+<svelte:window on:popstate={() => refresh_page()} />
 
 <Header/>
 {#if view === 'search'}

--- a/src/components/DetailsLink.svelte
+++ b/src/components/DetailsLink.svelte
@@ -4,7 +4,8 @@
   export let extra_classes = '';
   export let feature = null;
 
-  let url_params = '';
+  let url_params = new URLSearchParams();
+  let href = 'details.html';
 
   function formatShortOSMType(sType) {
     if (sType === 'node') return 'N';
@@ -14,29 +15,35 @@
   }
 
   function handleClick() {
-    window.history.pushState([], '', 'details.html' + url_params);
-    refresh_page();
+    refresh_page('details', url_params);
   }
 
   $: {
+    let new_params = new URLSearchParams();
+
     if (feature !== null && feature.osm_type) {
-      let param = '?osmtype=';
       if (feature.osm_type.length == 1) {
-        param += encodeURIComponent(feature.osm_type);
+        new_params.set('osmtype', feature.osm_type);
       } else {
-        param += formatShortOSMType(feature.osm_type);
+        new_params.set('osmtype', formatShortOSMType(feature.osm_type));
       }
-      param += '&osmid=' + encodeURIComponent(feature.osm_id);
+
+      new_params.set('osmid', feature.osm_id);
+
       if (feature.class) {
-        param += '&class=' + encodeURIComponent(feature.class);
+        new_params.set('class', feature.class);
       } else if (feature.category) {
-        param += '&class=' + encodeURIComponent(feature.category);
+        new_params.set('class', feature.category);
       }
-      url_params = param
-    } else {
-        url_params = '';
     }
+
+    url_params = new_params;
+ }
+
+ $: {
+   let param_str = url_params.toString();
+   href = 'details.html' + (param_str ? '?' : '') + param_str;
  }
 </script>
 
-<a on:click|preventDefault|stopPropagation={handleClick} href="details.html{url_params}" class={extra_classes}><slot></slot></a>
+<a on:click|preventDefault|stopPropagation={handleClick} href={href} class={extra_classes}><slot></slot></a>

--- a/src/components/DetailsLink.svelte
+++ b/src/components/DetailsLink.svelte
@@ -22,7 +22,7 @@
     let new_params = new URLSearchParams();
 
     if (feature !== null && feature.osm_type) {
-      if (feature.osm_type.length == 1) {
+      if (feature.osm_type.length === 1) {
         new_params.set('osmtype', feature.osm_type);
       } else {
         new_params.set('osmtype', formatShortOSMType(feature.osm_type));
@@ -38,12 +38,12 @@
     }
 
     url_params = new_params;
- }
+  }
 
- $: {
-   let param_str = url_params.toString();
-   href = 'details.html' + (param_str ? '?' : '') + param_str;
- }
+  $: {
+    let param_str = url_params.toString();
+    href = 'details.html' + (param_str ? '?' : '') + param_str;
+  }
 </script>
 
 <a on:click|preventDefault|stopPropagation={handleClick} href={href} class={extra_classes}><slot></slot></a>

--- a/src/components/PageLink.svelte
+++ b/src/components/PageLink.svelte
@@ -4,7 +4,7 @@ import { refresh_page } from '../lib/stores.js';
 export let page;
 
 function handleClick() {
-  refresh_page(page, {});
+  refresh_page(page);
 }
 </script>
 

--- a/src/components/PageLink.svelte
+++ b/src/components/PageLink.svelte
@@ -4,8 +4,7 @@ import { refresh_page } from '../lib/stores.js';
 export let page;
 
 function handleClick() {
-  window.history.pushState([], '', page + '.html');
-  refresh_page();
+  refresh_page(page, {});
 }
 </script>
 

--- a/src/components/ReverseBar.svelte
+++ b/src/components/ReverseBar.svelte
@@ -38,7 +38,7 @@
 </script>
 
 <div class="top-bar">
-  <UrlSubmitForm>
+  <UrlSubmitForm page="reverse">
     <div class="form-group">
       <input name="format" type="hidden" value="html">
       <label for="reverse-lat">lat</label>

--- a/src/components/ReverseBar.svelte
+++ b/src/components/ReverseBar.svelte
@@ -14,14 +14,16 @@
     let params = new URLSearchParams();
     params.set('lat', newlat);
     params.set('lon', newlon);
-    params.set('zoom', newzoom ? newzoom : zoom);
+    params.set('zoom', newzoom || zoom);
     refresh_page('reverse', params);
   }
 
   map_store.subscribe(map => {
     if (map) {
-      map.on('click', (e) => gotoCoordinates(e.latlng.lat.toFixed(5),
-                                             e.latlng.wrap().lng.toFixed(5)));
+      map.on('click', (e) => {
+        let coords = e.latlng.wrap();
+        gotoCoordinates(coords.lat.toFixed(5), coords.lng.toFixed(5));
+      });
     }
   });
 

--- a/src/components/ReverseLink.svelte
+++ b/src/components/ReverseLink.svelte
@@ -21,7 +21,7 @@ $: {
   }
 
   params = new_params;
-};
+}
 
 $: {
   let param_str = params.toString();

--- a/src/components/ReverseLink.svelte
+++ b/src/components/ReverseLink.svelte
@@ -5,27 +5,28 @@ export let lat;
 export let lon;
 export let zoom = null;
 
-let params = '';
+let params = new URLSearchParams();
+let href = 'reverse.html';
 
 $: {
+  let new_params = new URLSearchParams();
+
   if (lat && lon) {
-    let new_params = '?lat=' + encodeURIComponent(lat);
-    new_params += '&lon=' + encodeURIComponent(lon);
+    new_params.set('lat', lat);
+    new_params.set('lon', lon);
 
     if (zoom) {
-      new_params += '&zoom=' + encodeURIComponent(zoom);
+      new_params.set('zoom', zoom);
     }
-
-    params = new_params;
-  } else {
-    params = '';
   }
-}
 
-function handleClick() {
-  window.history.pushState([], '', 'reverse.html' + params);
-  refresh_page();
+  params = new_params;
+};
+
+$: {
+  let param_str = params.toString();
+  href = 'reverse.html' + (param_str ? '?' : '') + param_str;
 }
 </script>
 
-<a on:click|preventDefault|stopPropagation={handleClick} href="reverse.html{params}"><slot></slot></a>
+<a on:click|preventDefault|stopPropagation={() => refresh_page('reverse', params)} href={href}><slot></slot></a>

--- a/src/components/SearchBar.svelte
+++ b/src/components/SearchBar.svelte
@@ -95,7 +95,7 @@
   </ul>
   <div class="tab-content p-2">
     <div class="tab-pane" class:active={!bStructuredSearch} id="simple" role="tabpanel">
-      <UrlSubmitForm>
+      <UrlSubmitForm page="search">
         <input id="q"
                name="q"
                type="text"
@@ -116,7 +116,7 @@
       </UrlSubmitForm>
     </div>
     <div class="tab-pane" class:active={bStructuredSearch} id="structured" role="tabpanel">
-      <UrlSubmitForm>
+      <UrlSubmitForm page="search">
         <input name="street" type="text" class="form-control form-control-sm mr-1"
                placeholder="House number/Street"
                value="{api_request_params.street || ''}" />

--- a/src/components/UrlSubmitForm.svelte
+++ b/src/components/UrlSubmitForm.svelte
@@ -1,49 +1,24 @@
 <script>
   import { refresh_page } from '../lib/stores.js';
 
-  /*!
-   * Serialize all form data into a SearchParams string
-   * (c) 2020 Chris Ferdinandi, MIT License, https://gomakethings.com
-   * @param  {Node}   form The form to serialize
-   * @return {String}      The serialized form data
-   */
+  export let page;
+
   function serialize_form(form) {
-    var arr = [];
+    var params = new URLSearchParams();
+
     Array.prototype.slice.call(form.elements).forEach(function (field) {
       if (!field.name || field.disabled || ['submit', 'button'].indexOf(field.type) > -1) return;
 
       if (['checkbox', 'radio'].indexOf(field.type) > -1 && !field.checked) return;
-      if (typeof field.value === 'undefined') return;
-      arr.push(encodeURIComponent(field.name) + '=' + encodeURIComponent(field.value));
+      if (typeof field.value === 'undefined' || field.value === '') return;
+
+      params.set(field.name, field.value);
     });
-    return arr.join('&');
-  }
 
-  // remove any URL paramters with empty values
-  // '&empty=&filled=value' => 'filled=value'
-  function clean_up_url_parameters(url) {
-    var url_params = new URLSearchParams(url);
-    var to_delete = []; // deleting inside loop would skip iterations
-    url_params.forEach(function (value, key) {
-      if (value === '') to_delete.push(key);
-    });
-    for (var i = 0; i < to_delete.length; i += 1) {
-      url_params.delete(to_delete[i]);
-    }
-    return url_params.toString();
-  }
-
-  function handleSubmit(event) {
-    event.preventDefault();
-
-    var target_url = serialize_form(event.target);
-    target_url = clean_up_url_parameters(target_url);
-
-    window.history.pushState({}, '', '?' + target_url);
-    refresh_page(page, );
+    return params;
   }
 </script>
 
-<form on:submit={handleSubmit} class="form-inline" role="search" accept-charset="UTF-8" action="">
+<form on:submit|preventDefault={() => refresh_page(page, serialize_form(event.target))} class="form-inline" role="search" accept-charset="UTF-8" action="">
     <slot></slot>
 </form>

--- a/src/components/UrlSubmitForm.svelte
+++ b/src/components/UrlSubmitForm.svelte
@@ -1,6 +1,37 @@
 <script>
-  import { serialize_form, clean_up_url_parameters } from '../lib/api_utils.js';
   import { refresh_page } from '../lib/stores.js';
+
+  /*!
+   * Serialize all form data into a SearchParams string
+   * (c) 2020 Chris Ferdinandi, MIT License, https://gomakethings.com
+   * @param  {Node}   form The form to serialize
+   * @return {String}      The serialized form data
+   */
+  function serialize_form(form) {
+    var arr = [];
+    Array.prototype.slice.call(form.elements).forEach(function (field) {
+      if (!field.name || field.disabled || ['submit', 'button'].indexOf(field.type) > -1) return;
+
+      if (['checkbox', 'radio'].indexOf(field.type) > -1 && !field.checked) return;
+      if (typeof field.value === 'undefined') return;
+      arr.push(encodeURIComponent(field.name) + '=' + encodeURIComponent(field.value));
+    });
+    return arr.join('&');
+  }
+
+  // remove any URL paramters with empty values
+  // '&empty=&filled=value' => 'filled=value'
+  function clean_up_url_parameters(url) {
+    var url_params = new URLSearchParams(url);
+    var to_delete = []; // deleting inside loop would skip iterations
+    url_params.forEach(function (value, key) {
+      if (value === '') to_delete.push(key);
+    });
+    for (var i = 0; i < to_delete.length; i += 1) {
+      url_params.delete(to_delete[i]);
+    }
+    return url_params.toString();
+  }
 
   function handleSubmit(event) {
     event.preventDefault();
@@ -9,7 +40,7 @@
     target_url = clean_up_url_parameters(target_url);
 
     window.history.pushState({}, '', '?' + target_url);
-    refresh_page();
+    refresh_page(page, );
   }
 </script>
 

--- a/src/components/UrlSubmitForm.svelte
+++ b/src/components/UrlSubmitForm.svelte
@@ -19,6 +19,6 @@
   }
 </script>
 
-<form on:submit|preventDefault={() => refresh_page(page, serialize_form(event.target))} class="form-inline" role="search" accept-charset="UTF-8" action="">
+<form on:submit|preventDefault={(e) => refresh_page(page, serialize_form(e.target))} class="form-inline" role="search" accept-charset="UTF-8" action="">
     <slot></slot>
 </form>

--- a/src/lib/api_utils.js
+++ b/src/lib/api_utils.js
@@ -32,44 +32,6 @@ function generate_nominatim_api_url(endpoint_name, params) {
          }).join('&');
 }
 
-/*!
- * Serialize all form data into a SearchParams string
- * (c) 2020 Chris Ferdinandi, MIT License, https://gomakethings.com
- * @param  {Node}   form The form to serialize
- * @return {String}      The serialized form data
- */
-export function serialize_form(form) {
-  var arr = [];
-  Array.prototype.slice.call(form.elements).forEach(function (field) {
-    if (!field.name || field.disabled || ['submit', 'button'].indexOf(field.type) > -1) return;
-    // if (field.type === 'select-multiple') {
-    //   Array.prototype.slice.call(field.options).forEach(function (option) {
-    //     if (!option.selected) return;
-    //     arr.push(encodeURIComponent(field.name) + '=' + encodeURIComponent(option.value));
-    //   });
-    //   return;
-    // }
-    if (['checkbox', 'radio'].indexOf(field.type) > -1 && !field.checked) return;
-    if (typeof field.value === 'undefined') return;
-    arr.push(encodeURIComponent(field.name) + '=' + encodeURIComponent(field.value));
-  });
-  return arr.join('&');
-}
-
-
-// remove any URL paramters with empty values
-// '&empty=&filled=value' => 'filled=value'
-export function clean_up_url_parameters(url) {
-  var url_params = new URLSearchParams(url);
-  var to_delete = []; // deleting inside loop would skip iterations
-  url_params.forEach(function (value, key) {
-    if (value === '') to_delete.push(key);
-  });
-  for (var i = 0; i < to_delete.length; i += 1) {
-    url_params.delete(to_delete[i]);
-  }
-  return url_params.toString();
-}
 
 function clean_up_parameters(params) {
   // `&a=&b=&c=1` => '&c=1'

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -15,13 +15,8 @@ export function refresh_page(pagename, params) {
 
     params = new URLSearchParams(window.location.search);
   } else {
-    if (!(params instanceof URLSearchParams)) {
-      let urlparams = new URLSearchParams();
-      Object.keys(params).forEach((key, index) => {
-        urlparams.set(key, params[key]);
-      });
-
-      params = urlparams;
+    if (typeof params === 'undefined') {
+      params = new URLSearchParams();
     }
 
     let param_str = params.toString();

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -5,6 +5,16 @@ export const results_store = writable();
 export const last_api_request_url_store = writable();
 export const page = writable();
 
+/**
+ * Update the global page state.
+ *
+ * When called without a parameter, then the current window.location is
+ * parsed and the page state is set accordingly. Otherwise the page state
+ * is set from the parameters. 'pagename' is the overall subpage (without
+ * .html extension). 'params' must be an URLSearchParams object and contain
+ * the requested query parameters. It may also be omitted completely for a
+ * link without query parameters.
+ */
 export function refresh_page(pagename, params) {
   if (typeof pagename === 'undefined') {
     pagename = window.location.pathname.replace('.html', '').replace(/^.*\//, '');

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -3,16 +3,33 @@ import { writable } from 'svelte/store';
 export const map_store = writable();
 export const results_store = writable();
 export const last_api_request_url_store = writable();
-export const page = writable({ count: 0 });
+export const page = writable();
 
-export function refresh_page() {
-  let pagename = window.location.pathname.replace('.html', '').replace(/^.*\//, '');
+export function refresh_page(pagename, params) {
+  if (typeof pagename === 'undefined') {
+    pagename = window.location.pathname.replace('.html', '').replace(/^.*\//, '');
 
-  if (['search', 'reverse', 'details', 'deletable', 'polygons'].indexOf(pagename) === -1) {
-    pagename = 'search';
+    if (['search', 'reverse', 'details', 'deletable', 'polygons'].indexOf(pagename) === -1) {
+      pagename = 'search';
+    }
+
+    params = new URLSearchParams(window.location.search);
+  } else {
+    if (!(params instanceof URLSearchParams)) {
+      let urlparams = new URLSearchParams();
+      Object.keys(params).forEach((key, index) => {
+        urlparams.set(key, params[key]);
+      });
+
+      params = urlparams;
+    }
+
+    let param_str = params.toString();
+    if (param_str) {
+      param_str = '?' + param_str;
+    }
+    window.history.pushState([], '', pagename + '.html' + param_str);
   }
 
-  // Add a counter here to make sure the store change is triggered
-  // everytime we refresh, not just when the page changes.
-  page.update(function (v) { return { tab: pagename, count: v.count + 1 }; });
+  page.set({ tab: pagename, params: params });
 }

--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -40,6 +40,7 @@
       }
 
       fetch_from_api('details', api_request_params, function (data) {
+        window.scrollTo(0, 0)
         if (data.error) {
           errorResponse = data;
           current_result = undefined;

--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { onMount, onDestroy } from 'svelte';
   import { fetch_from_api, update_html_title } from '../lib/api_utils.js';
   import { page } from '../lib/stores.js';
 
@@ -18,9 +17,7 @@
   let base_url = window.location.search;
   let current_result;
 
-  function loaddata() {
-    var search_params = new URLSearchParams(window.location.search);
-
+  function loaddata(search_params) {
     var api_request_params = {
       place_id: search_params.get('place_id'),
       osmtype: search_params.get('osmtype'),
@@ -57,10 +54,12 @@
     }
   }
 
-  let page_subscription;
-  onMount(() => { page_subscription = page.subscribe(loaddata); });
-  onDestroy(() => { page_subscription(); });
-
+  $: {
+    let pageinfo = $page;
+    if (pageinfo.tab === 'details') {
+      loaddata(pageinfo.params);
+    }
+  }
 </script>
 
 {#if errorResponse}

--- a/src/pages/ReversePage.svelte
+++ b/src/pages/ReversePage.svelte
@@ -39,6 +39,8 @@
                             + api_request_params.lon);
         document.querySelector('input[name=lat]').focus();
       });
+    } else {
+      results_store.set(undefined);
     }
   }
 

--- a/src/pages/ReversePage.svelte
+++ b/src/pages/ReversePage.svelte
@@ -1,6 +1,4 @@
 <script>
-  import { onMount, onDestroy } from 'svelte';
-
   import { page, results_store } from '../lib/stores.js';
   import { get_config_value } from '../lib/config_reader.js';
   import { fetch_from_api, update_html_title } from '../lib/api_utils.js';
@@ -13,9 +11,7 @@
   let current_result;
   let position_marker; // what the user searched for
 
-  function loaddata() {
-    let search_params = new URLSearchParams(window.location.search);
-
+  function loaddata(search_params) {
     update_html_title();
 
     api_request_params = {
@@ -46,9 +42,12 @@
     }
   }
 
-  let page_subscription;
-  onMount(() => { page_subscription = page.subscribe(loaddata); });
-  onDestroy(() => { page_subscription(); });
+  $: {
+    let pageinfo = $page;
+    if (pageinfo.tab === 'reverse') {
+      loaddata(pageinfo.params);
+    }
+  }
 </script>
 
 <ReverseBar api_request_params={api_request_params} />

--- a/src/pages/ReversePage.svelte
+++ b/src/pages/ReversePage.svelte
@@ -50,7 +50,7 @@
   }
 </script>
 
-<ReverseBar api_request_params={api_request_params} />
+<ReverseBar {...api_request_params} />
 
 <div id="content">
   <div class="sidebar">

--- a/src/pages/SearchPage.svelte
+++ b/src/pages/SearchPage.svelte
@@ -1,6 +1,4 @@
 <script>
-  import { onMount, onDestroy } from 'svelte';
-
   import { page, results_store } from '../lib/stores.js';
   import { get_config_value } from '../lib/config_reader.js';
   import { fetch_from_api, update_html_title } from '../lib/api_utils.js';
@@ -13,9 +11,7 @@
   let bStructuredSearch;
   let current_result;
 
-  function loaddata() {
-    let search_params = new URLSearchParams(window.location.search);
-
+  function loaddata(search_params) {
     update_html_title();
 
     api_request_params = {
@@ -56,9 +52,12 @@
     }
   }
 
-  let page_subscription;
-  onMount(() => { page_subscription = page.subscribe(loaddata); });
-  onDestroy(() => { page_subscription(); });
+  $: {
+    let pageinfo = $page;
+    if (pageinfo.tab === 'search') {
+      loaddata(pageinfo.params);
+    }
+  }
 </script>
 
 <SearchBar api_request_params={api_request_params} bStructuredSearch={bStructuredSearch} />

--- a/src/pages/SearchPage.svelte
+++ b/src/pages/SearchPage.svelte
@@ -49,6 +49,8 @@
 
         document.querySelector('input[name=q]').focus();
       });
+    } else {
+      results_store.set(undefined);
     }
   }
 


### PR DESCRIPTION
The `refresh_page()` is now the go-to function for all page-internal linking. It now receives the page and parameters (as URLSearchParams), sets the page store accordingly and also updates the window.location. When called without parameters, refresh_page uses the parameters from the window location to update the page store (exactly like it did until now).

Pages directly subscribe to the page store and take the URL parameters from there. The PR also changes the ReverseBar to use refresh_page() instead of indirectly sending its form. This avoids the annoying double reload when clicking on the map.