### PR TITLE
Enable simple CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: "Continuous Integration"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '10.x'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Linting
+        run: yarn lint
+
+      - name: Build
+        run: yarn build

--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -40,7 +40,7 @@
       }
 
       fetch_from_api('details', api_request_params, function (data) {
-        window.scrollTo(0, 0)
+        window.scrollTo(0, 0);
         if (data.error) {
           errorResponse = data;
           current_result = undefined;


### PR DESCRIPTION
This enables a run of ' yarn lint'  and 'yarn build'  via github actions. It found a linting issue, so I fixed that here to make the CI pass.

See https://github.com/lonvia/nominatim-ui/actions/runs/572770602 for a successful run of this branch.