### PR TITLE
make sure webpages still work on file:// protocol

### DIFF
--- a/src/lib/api_utils.js
+++ b/src/lib/api_utils.js
@@ -33,17 +33,27 @@ export async function fetch_from_api(endpoint_name, params, callback) {
 
 var fetch_content_cache = {};
 export async function fetch_content_into_element(url, dom_element) {
+  if (!window.location.protocol.match(/^http/)) {
+    dom_element.innerHTML = `Cannot display data from ${url} here. `
+      + 'Browser security prevents loading content from file:// URLs.';
+    return;
+  }
+
   if (fetch_content_cache[url]) {
     dom_element.innerHTML = fetch_content_cache[url];
     return;
   }
-  await fetch(url)
-    .then(response => response.text())
-    .then(html => {
-      html = html.replace('Nominatim_API_Endpoint', Nominatim_Config.Nominatim_API_Endpoint);
-      dom_element.innerHTML = html;
-      fetch_content_cache[url] = html;
-    });
+  try {
+    await fetch(url)
+      .then(response => response.text())
+      .then(html => {
+        html = html.replace('Nominatim_API_Endpoint', Nominatim_Config.Nominatim_API_Endpoint);
+        dom_element.innerHTML = html;
+        fetch_content_cache[url] = html;
+      });
+  } catch (error) {
+    dom_element.innerHTML = `Error fetching content from ${url} (${error})`;
+  }
 }
 
 function generate_nominatim_api_url(endpoint_name, params) {

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -34,7 +34,13 @@ export function refresh_page(pagename, params) {
     if (param_str) {
       param_str = '?' + param_str;
     }
-    window.history.pushState([], '', pagename + '.html' + param_str);
+    let new_url = pagename + '.html' + param_str;
+
+    if (window.location.protocol.match(/^http/)) {
+      window.history.pushState([], '', new_url);
+    } else {
+      window.location.href = new_url;
+    }
   }
 
   page.set({ tab: pagename, params: params });


### PR DESCRIPTION
fixes https://github.com/osm-search/nominatim-ui/issues/92

It's not ideal. In Firefox CORS defaults to `http` so loading any content via `file://` (when you open, e.g. `search.html` directly from the filesytem in the browser) fails. Now we display an error at least. But navigating to other pages via `window.history.pushState` doesn't work either so for `file://` we have to disable it. Slower app, but at least it doesn't look completely broken.