### PR TITLE
Details: ignore missing computed postcode

### DIFF
--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -150,7 +150,7 @@
             {/if}
             <tr>
               <td>Computed Postcode</td>
-              <td>{aPlace.calculated_postcode}</td>
+              <td>{aPlace.calculated_postcode || ''}</td>
             </tr>
             <tr>
               <td>Address Tags</td>


### PR DESCRIPTION
Avoid displaying 'null' when the postcode is missing.