### PR TITLE
Make details information table responsive

### DIFF
--- a/src/components/DetailsInfoRowList.svelte
+++ b/src/components/DetailsInfoRowList.svelte
@@ -3,8 +3,9 @@
 </script>
 
 <style>
-  .name{
+  .name {
     font-weight: bold;
+    overflow-wrap: anywhere;
   }
 </style>
 

--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -80,7 +80,7 @@
     </div>
     <div class="row">
       <div class="col-md-6">
-        <table id="locationdetails" class="table table-striped">
+        <table id="locationdetails" class="table table-striped table-responsive">
           <tbody>
             <InfoRow title="Name"><InfoRowList items={aPlace.names} /></InfoRow>
             <InfoRow title="Type">{aPlace.category}:{aPlace.type}</InfoRow>
@@ -241,9 +241,6 @@
     padding-left: 0 !important;
   }
 
-  .table {
-    width: 100%;
-  }
   #map-wrapper {
     width:100%;
     min-height: auto;


### PR DESCRIPTION
Restricts size of table when long are added. Also allow arbitrary word wrap so that overly long values do not require scrolling.

Fixes #97.