### PR TITLE
detailspage: children, hierarchy link didnt update after new data loaded

### DIFF
--- a/src/components/DetailsOneRow.svelte
+++ b/src/components/DetailsOneRow.svelte
@@ -7,12 +7,13 @@
 
   export let addressLine;
   export let bDistanceInMeters;
+  export let bMarkUnusedLines = false;
 
   $: bAddressLineUsed = addressLine.isaddress;
 
 </script>
 
-<tr class:notused={!bAddressLineUsed}>
+<tr class:notused={bMarkUnusedLines && !bAddressLineUsed}>
   <td class="name font-weight-bold">
     {#if addressLine.localname}
       {addressLine.localname}
@@ -29,9 +30,9 @@
     {#if addressLine.osm_id}
       <DetailsLink feature={addressLine}>details</DetailsLink>
     {:else if addressLine.type.match(/^country/)}
-      <PageLink page='search', params_hash={{ country: addressLine.localname }}>search by name</PageLink>
+      <PageLink page='search' params_hash={{ country: addressLine.localname }}>search by name</PageLink>
     {:else if addressLine.type === 'postcode'}
-      <PageLink page='search', params_hash={{ postalcode: addressLine.localname }}>search by name</PageLink>
+      <PageLink page='search' params_hash={{ postalcode: addressLine.localname }}>search by name</PageLink>
     {/if}
   </td>
 </tr>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -67,20 +67,20 @@
       <!-- Left-aligned links -->
       <ul class="navbar-nav mr-auto">
         <li class="nav-item {view === 'search' ? 'active' : ''}">
-          <PageLink page="search" extra_classes="nav-link ">Search</PageLink>
+          <PageLink page="search" extra_classes="nav-link">Search</PageLink>
         </li>
         <li class="nav-item {view === 'reverse' ? 'active' : ''}">
           <ReverseLink extra_classes="nav-link ">Reverse</ReverseLink>
         </li>
         <li class="nav-item {view === 'details' ? 'active' : ''}">
-          <PageLink page="details" extra_classes="nav-link ">Search By ID</PageLink>
+          <PageLink page="details" extra_classes="nav-link">Search By ID</PageLink>
         </li>
       </ul>
     </div>
     <!-- Right aligned links -->
     <ul class="navbar-nav">
       <li class="nav-item {view === 'about' ? 'active' : ''}">
-        <PageLink page="about" extra_classes="nav-link ">About & Help</PageLink>
+        <PageLink page="about" extra_classes="nav-link">About & Help</PageLink>
       </li>
     </ul>
   </nav>

--- a/src/components/ReverseLink.svelte
+++ b/src/components/ReverseLink.svelte
@@ -1,8 +1,8 @@
 <script>
 import { refresh_page } from '../lib/stores.js';
 
-export let lat;
-export let lon;
+export let lat = null;
+export let lon = null;
 export let zoom = null;
 export let extra_classes = '';
 

--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -16,7 +16,7 @@
   import Map from '../components/Map.svelte';
 
   let aPlace;
-  let base_url = window.location.search;
+  let base_url;
   let api_request_params;
   let api_request_finished = false;
 
@@ -57,6 +57,7 @@
     let pageinfo = $page;
     if (pageinfo.tab === 'details') {
       loaddata(pageinfo.params);
+      base_url = window.location.search;
     }
   }
 </script>
@@ -138,14 +139,14 @@
           <tbody>
             {#if aPlace.address}
               {#each aPlace.address as addressLine}
-                <DetailsOneRow addressLine={addressLine} bDistanceInMeters=false />
+                <DetailsOneRow addressLine={addressLine} bMarkUnusedLines=true bDistanceInMeters=false />
               {/each}
             {/if}
 
             {#if aPlace.linked_places}
               <tr class="all-columns"><td colspan="6"><h2>Linked Places</h2></td></tr>
               {#each aPlace.linked_places as addressLine}
-                <DetailsOneRow addressLine={addressLine} bDistanceInMeters=true />
+                <DetailsOneRow addressLine={addressLine} bMarkUnusedLines=true bDistanceInMeters=true />
               {/each}
             {/if}
 
@@ -161,15 +162,17 @@
                 </tr>
               {/each}
 
-              <tr class="all-columns"><td colspan="6"><h3>Address Keywords</h3></td></tr>
-              {#each aPlace.keywords.address as keyword}
-                <tr>
-                  <td>{formatKeywordToken(keyword.token)}</td>
-                  {#if keyword.id}
-                    <td>word id: {keyword.id}</td>
-                  {/if}
-              </tr>
-              {/each}
+              {#if aPlace.keywords.address}
+                <tr class="all-columns"><td colspan="6"><h3>Address Keywords</h3></td></tr>
+                {#each aPlace.keywords.address as keyword}
+                  <tr>
+                    <td>{formatKeywordToken(keyword.token)}</td>
+                    {#if keyword.id}
+                      <td>word id: {keyword.id}</td>
+                    {/if}
+                  </tr>
+                {/each}
+              {/if}
             {:else}
               <tr>
                 <td>


### PR DESCRIPTION
- links on detailpage didn't update after new data was loaded, fixes https://github.com/osm-search/nominatim-ui/issues/99
- API doesn't always return address keywords
- when displaying hierarchy don't mark all lines unused, only do that in the first addressline table
- fix "unknown property ',' in PageLink" warning
- fix "lat,lon not set in ReverseLink" warning