### PR TITLE
validate countrycodes, lat, lon fields even when hidden

### DIFF
--- a/src/components/SearchSection.svelte
+++ b/src/components/SearchSection.svelte
@@ -101,7 +101,8 @@
       <input type="hidden" name="dedupe" value="{!api_request_params.dedupe ? '' : 1}" />
       <input type="hidden" name="bounded" value="{api_request_params.bounded ? 1 : ''}" />
       <input type="hidden" name="accept-language" value="{api_request_params['accept-language'] || ''}" />
-      <input type="hidden" name="countrycodes" value="{api_request_params.countrycodes || ''}" />
+      <input type="hidden" name="countrycodes" value="{api_request_params.countrycodes || ''}"
+                                                    pattern="^[a-zA-Z]{'{2}'}(,[a-zA-Z]{'{2}'})*$" />
       <input type="hidden" name="limit" value="{api_request_params.limit || ''}" />
       <input type="hidden" name="polygon_threshold" value="{api_request_params.polygon_threshold || ''}" />
     </UrlSubmitForm>
@@ -132,7 +133,8 @@
       <input type="hidden" name="dedupe" value="{!api_request_params.dedupe ? '' : 1}" />
       <input type="hidden" name="bounded" value="{api_request_params.bounded ? 1 : ''}" />
       <input type="hidden" name="accept-language" value="{api_request_params['accept-language'] || ''}" />
-      <input type="hidden" name="countrycodes" value="{api_request_params.countrycodes || ''}" />
+      <input type="hidden" name="countrycodes" value="{api_request_params.countrycodes || ''}"
+                                              pattern="^[a-zA-Z]{'{2}'}(,[a-zA-Z]{'{2}'})*$" />
       <input type="hidden" name="limit" value="{api_request_params.limit || ''}" />
       <input type="hidden" name="polygon_threshold" value="{api_request_params.polygon_threshold || ''}" />
     </UrlSubmitForm>
@@ -194,8 +196,9 @@
     <li>
       <label for="option_ccode">Country Codes</label>
       <input type="text" placeholder="e.g. de,gb" class="form-control form-control-sm d-inline w-auto api-param-setting"
-             data-api-param="countrycodes" id="option_ccode" size="15" pattern="[a-zA-Z]{2}(,[a-zA-Z]{2})*"
+             data-api-param="countrycodes" id="option_ccode" size="15"
              value="{api_request_params.countrycodes || ''}"
+             pattern="^[a-zA-Z]{'{2}'}(,[a-zA-Z]{'{2}'})*$"
              on:change={set_api_param}>
     </li>
   </ul>

--- a/src/components/SearchSectionReverse.svelte
+++ b/src/components/SearchSectionReverse.svelte
@@ -44,6 +44,7 @@
            type="text"
            class="form-control form-control-sm"
            placeholder="latitude"
+           pattern="^-?\d+(\.\d+)?$"
            bind:value={lat}
            on:change={maybeSplitLatitude} />
   </div>
@@ -60,6 +61,7 @@
            type="text"
            class="form-control form-control-sm"
            placeholder="longitude"
+           pattern="^-?\d+(\.\d+)?$"
            bind:value={lon} />
   </div>
   <div class="form-group">

--- a/src/components/UrlSubmitForm.svelte
+++ b/src/components/UrlSubmitForm.svelte
@@ -17,8 +17,32 @@
 
     return params;
   }
+
+  // https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation
+  // doesn't support hidden fields, so we check those in an extra step
+  function validate_field(field) {
+    if (field.type === 'hidden') {
+      if (field.pattern && !field.value.match(field.pattern)) return false;
+    }
+    return field.checkValidity(); // for hidden field always true
+  }
+
+  function handle_submit(event) {
+    let form = event.target;
+
+    let allow_submit = true;
+
+    Array.prototype.slice.call(form.elements).forEach(function (field) {
+      if (!validate_field(field)) {
+        alert('Invalid input in ' + field.name);
+        allow_submit = false;
+      }
+    });
+
+    if (allow_submit) refresh_page(page, serialize_form(form));
+  }
 </script>
 
-<form on:submit|preventDefault={(e) => refresh_page(page, serialize_form(e.target))} class="form-inline" role="search" accept-charset="UTF-8" action="">
+<form on:submit|preventDefault={handle_submit} class="form-inline" role="search" accept-charset="UTF-8" action="">
   <slot></slot>
 </form>


### PR DESCRIPTION
* https://github.com/osm-search/nominatim-ui/pull/108 didn't quite work yet,  the `{2}` in the regex pattern needed escaping in Svelte syntax.

* on /search and /reverse disallow submitting the form fields validate
* add validation for `lat` and `lon` on /reverse page
* for advanced search field we copy the value into hidden fields before submitting the form. Browsers don't validate hidden fields, so we needed our own logic