### PR TITLE
filter build warning about undefined Nominatim_Config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,6 +36,11 @@ export default {
 		name: 'app',
 		file: 'dist/build/bundle.js'
 	},
+	onwarn(warning, warn) {
+		if (warning.plugin === 'svelte' && warning.message.match(/Nominatim_Config.* is not defined/)) return;
+
+    	warn(warning);
+	},
 	plugins: [
 		svelte({
 			compilerOptions: {


### PR DESCRIPTION
`yarn build` warnings about `Nominatim_Config` not defined when compiling `src/pages/StatusPage.svelte`. Filter this warning because it will be set when loading the page in a browser.