### PR TITLE
Cut down number of status fetch requests

### DIFF
--- a/src/components/LastUpdated.svelte
+++ b/src/components/LastUpdated.svelte
@@ -6,11 +6,17 @@
 
   let last_updated_date;
   let last_api_request_url;
+  let fetch_running = false; // prevent multiple parallel fetch runs
 
   last_api_request_url_store.subscribe(url => {
+    if (fetch_running || last_updated_date) return;
+
+    fetch_running = true;
+
     last_api_request_url = url;
     fetch_from_api('status', { format: 'json' }, function (data) {
       last_updated_date = data.data_updated;
+      fetch_running = false;
     });
   });
 </script>


### PR DESCRIPTION
Fixes https://github.com/osm-search/nominatim-ui/issues/120

We can still add caching the response and timestamp of the last fetch (https://github.com/osm-search/nominatim-ui/issues/65) but that's more complex.