### PR TITLE
MapIcon: make sure title and url get updated when place changes

### DIFF
--- a/src/components/MapIcon.svelte
+++ b/src/components/MapIcon.svelte
@@ -2,10 +2,9 @@
 
   export let aPlace;
 
-  let sIcon = getIcon(aPlace.category, aPlace.type);
-
-  let title = 'icon for ' + aPlace.category + ' ' + aPlace.type;
-  let url = Nominatim_Config.Images_Base_Url + sIcon + '.p.20.png';
+  $: sIcon = getIcon(aPlace.category, aPlace.type);
+  $: title = 'icon for ' + aPlace.category + ' ' + aPlace.type;
+  $: url = Nominatim_Config.Images_Base_Url + sIcon + '.p.20.png';
 
   function getIcon(category, type) {
     // equivalent to PHP Nominatim::ClassTypes::getIcon


### PR DESCRIPTION
fixes https://github.com/osm-search/nominatim-ui/issues/124

Took a bit trial and error. Svelte seems to have cached the values of `url` and `title`.