### PR TITLE
testcase that search result displays API and debug link

### DIFF
--- a/test/search.js
+++ b/test/search.js
@@ -36,6 +36,11 @@ describe('Search Page', function () {
       assert.equal(await page.title(), 'Result for City of London | Nominatim Demo');
     });
 
+    it('should display the API request and debug URL', async function () {
+      let link_titles = await page.$$eval('#api-request a', links => links.map(l => l.innerHTML));
+      assert.deepEqual(link_titles, ['API request', 'debug output']);
+    });
+
     it('should display a map', async function () {
       await page.waitForSelector('#map');
       assert.equal((await page.$$('#map')).length, 1);


### PR DESCRIPTION
Test case for https://github.com/osm-search/nominatim-ui/issues/123 Not ideal, I couldn't figure out how to access the `href` property.