### PR TITLE
Feat: Added basic tests for all pages

### DIFF
--- a/test/about.js
+++ b/test/about.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+
+describe('About Page', function () {
+  let page;
+
+  before(async function () {
+    page = await browser.newPage();
+    await page.goto('http://localhost:9999/about.html');
+  });
+
+  after(async function () {
+    await page.close();
+  });
+
+  it('should contain Nominatim description', async function () {
+    await page.waitForSelector('#about-help');
+    let description = await page.$eval('#about-help', el => el.textContent);
+
+    assert.ok(description.includes('Nominatim is a search engine'));
+  });
+});

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+
+describe('Browser behaviour', function () {
+
+  it('should have a user-agent', async function () {
+    let user_agent = await browser.userAgent();
+    assert.strictEqual(user_agent,
+      'Nominatim UI test suite Mozilla/5.0 Gecko/20100101 HeadlessChrome/90.0');
+  });
+});

--- a/test/details.js
+++ b/test/details.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+
+describe('Details Page', function () {
+  let page;
+
+  describe('No search', function () {
+    before(async function () {
+      page = await browser.newPage();
+      await page.goto('http://localhost:9999/details.html');
+    });
+
+    after(async function () {
+      await page.close();
+    });
+
+    it('should have a HTML page title', async function () {
+      assert.equal(await page.title(), 'Nominatim Demo');
+    });
+  });
+
+  describe('With search', function () {
+    before(async function () {
+      page = await browser.newPage();
+      await page.goto('http://localhost:9999/details.html');
+      await page.type('input[type=edit]', 'W5013364');
+      await page.click('button[type=submit]');
+      await page.waitForSelector('.container .row');
+    });
+
+    after(async function () {
+      await page.close();
+    });
+
+    it('should have header title as Eiffel Tower', async function () {
+      let page_header = await page.$eval('.container h1', el => el.textContent);
+
+      assert.ok(page_header.includes('Eiffel Tower'));
+    });
+
+    it('should have link to https://www.openstreetmap.org/way/5013364', async function () {
+
+      assert.strictEqual((await page.$$('a[href="https://www.openstreetmap.org/way/5013364"]')).length, 1);
+    });
+
+    it('should change page url and add new header on clicking display keywords', async function () {
+      let current_url;
+      let display_headers;
+      let [display_keywords_btn] = await page.$x("//a[contains(text(), 'display keywords')]");
+
+      await display_keywords_btn.click();
+      await page.waitForNavigation();
+
+      current_url = new URL(await page.url());
+      assert.strictEqual(current_url.searchParams.get('keywords'), '1');
+
+      await page.waitForSelector('h3');
+      display_headers = await page.$$eval('h3', elements => elements.map(el => el.textContent));
+      assert.deepStrictEqual(display_headers, ['Name Keywords', 'Address Keywords']);
+    });
+
+    it('should change page url on clicking display child places', async function () {
+      let current_url;
+      let [child_places_btn] = await page.$x("//a[contains(text(), 'display child places')]");
+
+      await child_places_btn.click();
+      await page.waitForNavigation();
+
+      current_url = new URL(await page.url());
+      assert.strictEqual(current_url.searchParams.get('hierarchy'), '1');
+    });
+  });
+});

--- a/test/reverse.js
+++ b/test/reverse.js
@@ -33,4 +33,42 @@ describe('Reverse Page', function () {
       assert.equal(await lon_handle.evaluate(node => node.value), 5);
     });
   });
+
+  describe('With search', function () {
+    before(async function () {
+      page = await browser.newPage();
+      await page.goto('http://localhost:9999/reverse.html');
+      await page.type('input[name=lat]', '27.1750090510034');
+      await page.type('input[name=lon]', '78.04209025');
+      await page.click('button[type=submit]');
+      await page.waitForSelector('#searchresults');
+    });
+
+    after(async function () {
+      await page.close();
+    });
+
+    it('should return single result', async function () {
+      let results_count = await page.$$eval('#searchresults .result', elements => elements.length);
+
+      assert.deepStrictEqual(results_count, 1);
+    });
+
+    it('should display a map', async function () {
+      await page.waitForSelector('#map');
+      assert.equal((await page.$$('#map')).length, 1);
+    });
+
+    it('should redirect to details page on clicking details button', async function () {
+      let current_url;
+      let results = await page.$$('#searchresults .result a');
+
+      await results[0].click();
+      await page.waitForNavigation();
+
+      current_url = new URL(await page.url());
+
+      assert.deepStrictEqual(current_url.pathname, '/details.html');
+    });
+  });
 });

--- a/test/search.js
+++ b/test/search.js
@@ -16,6 +16,44 @@ describe('Search Page', function () {
     it('should have a HTML page title', async function () {
       assert.equal(await page.title(), 'Nominatim Demo');
     });
+
+    it('should have a welcome message', async function () {
+      let welcome_message = await page.$eval('#welcome h2', el => el.textContent);
+      assert.deepStrictEqual(welcome_message, 'Welcome to Nominatim');
+    });
+
+    it('should have a last_updated_: ... ago data', async function () {
+      await page.waitForSelector('abbr[id="data-date"]');
+
+      let last_updated = await page.$eval('abbr[id="data-date"]', el => el.textContent);
+      assert.ok(last_updated.includes('ago'));
+    });
+
+    it('should show map bounds buttons', async function () {
+      await page.waitForSelector('#map');
+      let show_map_pos_handle = await page.$('#show-map-position');
+      let map_pos_handle = await page.$('#map-position');
+
+      await show_map_pos_handle.click();
+      assert.strictEqual(await map_pos_handle.evaluate(node => node.style.display), 'block');
+
+      let map_pos_details = await page.$eval('#map-position-inner', el => el.textContent);
+      map_pos_details = map_pos_details.split(' \n');
+
+      let map_center_coor = map_pos_details[0]
+        .split('map center: ')[1].split(' view')[0].split(',');
+      let map_zoom = map_pos_details[1].split('map zoom: ')[1];
+      let map_viewbox = map_pos_details[2].split('viewbox: ')[1].split(',');
+      let last_click = map_pos_details[3].split('last click: ')[1];
+
+      assert.deepStrictEqual(map_center_coor.length, 2);
+      assert.ok(map_zoom);
+      assert.deepStrictEqual(map_viewbox.length, 4);
+      assert.deepStrictEqual(last_click, 'undefined');
+
+      await page.click('#map-position-close a');
+      assert.strictEqual(await map_pos_handle.evaluate(node => node.style.display), 'none');
+    });
   });
 
   describe('Search for City of London', function () {
@@ -36,6 +74,21 @@ describe('Search Page', function () {
       assert.equal(await page.title(), 'Result for City of London | Nominatim Demo');
     });
 
+    it('should have added search params', async function () {
+      let current_url = new URL(await page.url());
+      assert.strictEqual(current_url.searchParams.get('q'), 'City of London');
+    });
+
+    it('should atleast one result', async function () {
+      let results_count = await page.$$eval('#searchresults .result', elements => elements.length);
+      assert.ok(results_count > 1);
+    });
+
+    it('should have show more results button', async function () {
+      let [search_more_btn] = await page.$x("//a[contains(text(), 'Search for more results')]");
+      assert.ok(search_more_btn);
+    });
+
     it('should display the API request and debug URL', async function () {
       let link_titles = await page.$$eval('#api-request a', links => links.map(l => l.innerHTML));
       assert.deepEqual(link_titles, ['API request', 'debug output']);
@@ -44,6 +97,26 @@ describe('Search Page', function () {
     it('should display a map', async function () {
       await page.waitForSelector('#map');
       assert.equal((await page.$$('#map')).length, 1);
+    });
+
+    it('should have polygon and marker in map and minimap', async function () {
+      assert.strictEqual((await page.$$('#map .leaflet-overlay-pane path')).length, 4);
+    });
+
+    it('should redirect to details page on clicking details button', async function () {
+      let current_url;
+      let page_header;
+      let results = await page.$$('#searchresults .result a');
+
+      await results[0].click();
+      await page.waitForNavigation();
+
+      current_url = new URL(await page.url());
+      assert.deepStrictEqual(current_url.pathname, '/details.html');
+
+      await page.waitForSelector('.container h1');
+      page_header = await page.$eval('.container h1', el => el.textContent);
+      assert.ok(page_header.includes('City of London'));
     });
   });
 });

--- a/test/status.js
+++ b/test/status.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+
+describe('Status Page', function () {
+  let page;
+
+  before(async function () {
+    page = await browser.newPage();
+    await page.goto('http://localhost:9999/status.html');
+  });
+
+  after(async function () {
+    await page.close();
+  });
+
+  it('should have software version', async function () {
+    // waits for fetching status details
+    await page.waitForFunction(
+      'document.querySelector(".col-sm-12 dl dd:nth-child(4)").textContent !== "undefined"'
+    );
+    let status_name = await page.$$eval('.col-sm-12 dl dt', elements => elements[1].textContent);
+    let version = await page.$$eval('.col-sm-12 dl dd', elements => elements[1].textContent);
+
+    assert.deepStrictEqual(status_name, 'Software version');
+    assert.ok(version !== 'undefined' && version.length > 1);
+  });
+});


### PR DESCRIPTION
Fixes: #129

## Tests  includes:

### About Page
- [x] check page contains 'Nominatim is a search engine'

### Status Page
- [x] check page shows a Software version

### Search Page
#### No search
- [x] check the HTML page title
- [x] check if 'Data last updated: ... ago' is displayed
- [x] check if there is a welcome message "Welcome to Nominatim" 
- [x] check if a map is displayed
- [x] click 'show map bounds' buttons
- [x] check the '#map-position' element is displayed
- [x] check the map center contains two coordinates
- [x] check the map zoom contains a number
- [x] check the viewbox contains four coordinates
- [x] check last click is empty/undefined
- [x] click the 'hide' button
- [x] check the '#map-position' element is no longer displayed
#### With search
- [x] fill form with 'city of london'
- [x] press the search button
- [x] check which URL path got loaded
- [x] check if at least one result is displayed, count '.searchresults .result' elements
- [x] check if 'Search for more results' button is displayed
- [x] check if link to the raw API URL is displayed,
- [x] check if link to the raw debug API URL is displayed
- [x] check if map is displayed
- [x] check if map and minimap contains a marker and polygon, look for 4 'leaflet-overlay-pane path' elements
- [x] click on first 'details' link in the results and check that a new page gets loaded, which is a detail page and has a title ('h1' elements) with text 'City of London'

### Reverse Page
- [x] fill form with lat=27.1750090510034, lon=78.04209025 and submit
- [x] check there is one result, count '.searchresults .result' elements
- [x] click the 'details' link in the result, check that the page is now a details page/url

### Details Page
- [x] open details.html
- [x] fill form with W5013364 and submit
- [x] check H1 title is 'Eiffel Tower'
- [x] check there is a link to https://www.openstreetmap.org/way/5013364
- [x] click 'display keywords'
- [x] check the URL now contains 'keywords=1'
- [x] check the page now has a header 'Name Keywords' and 'Address Keywords'
- [x] click 'display child places'
- [x] check the URL now contains 'hierarchy=1'
- [ ]  check the page now has a header 'Parent Of' (Didn't add it because whether we click on display child places or not, 'Parent Of ' is always displayed)

### Browser config
- [x] checks user-agent is set