### PR TITLE
"yarn test" should run "yarn build" first to avoid outdated bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "lint": "eslint --quiet .*.js src/ test/",
-    "test": "mocha --recursive test/",
+    "test": "rollup -c && mocha --recursive test/",
     "start": "static-server dist"
   },
   "devDependencies": {


### PR DESCRIPTION
In `test/_bootstrap.js` we copy files from the `dist` directory to `dist_for_testing`. During regular development with `yarn dev` watching for file changes that was fine. But without then the `bundle.js` might be outdated. Or if running `yarn test` on a newly clones repository the `bundle.js` might not exist at all failing all tests.