### PR TITLE
detail page: fix display when keywords from API are empty

### DIFF
--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -163,20 +163,11 @@
             {/if}
 
             <tr class="all-columns"><td colspan="6"><h2>Keywords</h2></td></tr>
-            {#if aPlace.keywords}
-              <tr class="all-columns"><td colspan="6"><h3>Name Keywords</h3></td></tr>
-              {#each aPlace.keywords.name as keyword}
-                <tr>
-                  <td>{formatKeywordToken(keyword.token)}</td>
-                  {#if keyword.id}
-                    <td>word id: {keyword.id}</td>
-                  {/if}
-                </tr>
-              {/each}
+            {#if api_request_params.keywords}
 
-              {#if aPlace.keywords.address}
-                <tr class="all-columns"><td colspan="6"><h3>Address Keywords</h3></td></tr>
-                {#each aPlace.keywords.address as keyword}
+              {#if aPlace.keywords && (aPlace.keywords.name || aPlace.keywords.address) }
+                <tr class="all-columns"><td colspan="6"><h3>Name Keywords</h3></td></tr>
+                {#each aPlace.keywords.name as keyword}
                   <tr>
                     <td>{formatKeywordToken(keyword.token)}</td>
                     {#if keyword.id}
@@ -184,6 +175,20 @@
                     {/if}
                   </tr>
                 {/each}
+
+                {#if aPlace.keywords.address}
+                  <tr class="all-columns"><td colspan="6"><h3>Address Keywords</h3></td></tr>
+                  {#each aPlace.keywords.address as keyword}
+                    <tr>
+                      <td>{formatKeywordToken(keyword.token)}</td>
+                      {#if keyword.id}
+                        <td>word id: {keyword.id}</td>
+                      {/if}
+                    </tr>
+                  {/each}
+                {/if}
+              {:else}
+                <tr><td>Place has no keywords</td></tr>
               {/if}
             {:else}
               <tr>
@@ -195,17 +200,21 @@
             {/if}
 
             <tr class="all-columns"><td colspan="6"><h2>Parent Of</h2></td></tr>
-            {#if aPlace.hierarchy}
+            {#if api_request_params.hierarchy}
+              {#if aPlace.hierarchy && aPlace.hierarchy.length}
 
-              {#each Object.keys(aPlace.hierarchy) as type}
-                <tr class="all-columns"><td colspan="6"><h3>{type}</h3></td></tr>
-                {#each aPlace.hierarchy[type] as line}
-                  <DetailsOneRow addressLine={line} bDistanceInMeters=true />
-               {/each}
-              {/each}
+                {#each Object.keys(aPlace.hierarchy) as type}
+                  <tr class="all-columns"><td colspan="6"><h3>{type}</h3></td></tr>
+                  {#each aPlace.hierarchy[type] as line}
+                    <DetailsOneRow addressLine={line} bDistanceInMeters=true />
+                 {/each}
+                {/each}
 
-              {#if Object.keys(aPlace.hierarchy) > 500}
-                <p>There are more child objects which are not shown.</p>
+                {#if Object.keys(aPlace.hierarchy) > 500}
+                  <p>There are more child objects which are not shown.</p>
+                {/if}
+              {:else}
+                <tr><td>Place is not parent of other places</td></tr>
               {/if}
             {:else}
               <tr>

--- a/test/details.js
+++ b/test/details.js
@@ -18,7 +18,28 @@ describe('Details Page', function () {
     });
   });
 
-  describe('With search', function () {
+  describe('With search - no place found', function () {
+    before(async function () {
+      page = await browser.newPage();
+      await page.goto('http://localhost:9999/details.html');
+      await page.type('input[type=edit]', 'n3');
+      await page.click('button[type=submit]');
+      await page.waitForSelector('#api-request');
+    });
+
+
+    it('should display error', async function () {
+      let page_content = await page.$eval('body', el => el.textContent);
+
+      assert.ok(page_content.includes('No place with that OSM ID found'));
+    });
+
+    after(async function () {
+      await page.close();
+    });
+  });
+
+  describe('With search - Eiffel Tower', function () {
     before(async function () {
       page = await browser.newPage();
       await page.goto('http://localhost:9999/details.html');
@@ -77,6 +98,27 @@ describe('Details Page', function () {
 
       await page.waitForSelector('a[href="https://www.openstreetmap.org/way/375257537"]');
       assert.ok((await page.$eval('.container h1', el => el.textContent)).includes('Taj Mahal'));
+    });
+  });
+
+  describe('Place without name, keywords, hierarchy', function () {
+    // e.g. a numeric house number
+    before(async function () {
+      page = await browser.newPage();
+      await page.goto('http://localhost:9999/details.html?osmtype=N&osmid=946563004&keywords=1&hierarchy=1');
+      await page.waitForSelector('.container .row');
+    });
+
+    after(async function () {
+      await page.close();
+    });
+
+    it('should display No Name, no keywords, no hierarchy', async function () {
+      let page_content = await page.$eval('body', el => el.textContent);
+
+      assert.ok(page_content.includes('Name No Name'));
+      assert.ok(page_content.includes('Place has no keywords'));
+      assert.ok(page_content.includes('Place is not parent of other places'));
     });
   });
 });


### PR DESCRIPTION
fixes https://github.com/osm-search/nominatim-ui/issues/152

Also no longer display "display keywords" button when keywords were already requested from API.