### PR TITLE
Helper check for details keywords

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -47,6 +47,12 @@ The `test/` setup uses [Mocha](https://mochajs.org/) to run tests. Tests use [Pu
    port. That's a rare setup but something https://nominatim.openstreetmap.org/ does
    so worth testing.
 
+   To run a single test file only
+
+   ```
+   yarn run rollup -c && yarn run mocha test/details.js
+   ```
+
 * Run syntax linter (configuration in `.eslint.js`)
 
    ```

--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -54,6 +54,14 @@
     }
   }
 
+  function place_has_keywords(aThisPlace) {
+    // Return false if Nominatim API sends 'keywords: { name: [], address: [] }'
+    return (
+      aThisPlace.keywords && aThisPlace.keywords.name && aThisPlace.keywords.address
+      && (aThisPlace.keywords.name.length > 0 || aThisPlace.keywords.address.length > 0)
+    );
+  }
+
   $: {
     let pageinfo = $page;
     if (pageinfo.tab === 'details') {
@@ -165,7 +173,7 @@
             <tr class="all-columns"><td colspan="6"><h2>Keywords</h2></td></tr>
             {#if api_request_params.keywords}
 
-              {#if aPlace.keywords && (aPlace.keywords.name || aPlace.keywords.address) }
+              {#if place_has_keywords(aPlace)}
                 <tr class="all-columns"><td colspan="6"><h3>Name Keywords</h3></td></tr>
                 {#each aPlace.keywords.name as keyword}
                   <tr>


### PR DESCRIPTION
Nominatim API started to return a hash instead of array when no keywords are present, see https://github.com/osm-search/Nominatim/pull/2332