### PR TITLE
new config option -Reverse_Only-

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
         run: yarn build
       
       - name: Testing
-        run: |
-          yarn test
-          API_ON_SAME_PORT=1 yarn test
+        run: yarn test
+
+      - name: Testing API_ON_SAME_PORT
+        run: API_ON_SAME_PORT=1 yarn test
+
+      - name: Testing REVERSE_ONLY
+        run: REVERSE_ONLY=1 yarn test

--- a/dist/config.defaults.js
+++ b/dist/config.defaults.js
@@ -12,6 +12,9 @@ let Nominatim_Config = {
   // Additional query parameters for Nominatim API.
   Nominatim_API_Endpoint_Params: {},
 
+  // If database has no search index, then hide search page
+  Reverse_Only: false,
+
   // relative path or full URL
   Images_Base_Url: 'mapicons/',
 

--- a/dist/search.html
+++ b/dist/search.html
@@ -14,6 +14,12 @@
 
   <script src='config.defaults.js'></script>
   <script src='theme/config.theme.js'></script>
+
+  <script>
+    if (Nominatim_Config.Reverse_Only) {
+      window.location.pathname = window.location.pathname.replace('search.html', 'reverse.html');
+    }
+  </script>
   <script defer src='build/bundle.js'></script>
 </head>
 

--- a/src/components/DetailsOneRow.svelte
+++ b/src/components/DetailsOneRow.svelte
@@ -10,7 +10,7 @@
   export let bMarkUnusedLines = false;
 
   $: bAddressLineUsed = addressLine.isaddress;
-
+  $: reverse_only = Nominatim_Config.Reverse_Only;
 </script>
 
 <tr class:notused={bMarkUnusedLines && !bAddressLineUsed}>
@@ -29,9 +29,9 @@
   <td>
     {#if addressLine.osm_id}
       <DetailsLink feature={addressLine}>details</DetailsLink>
-    {:else if addressLine.type.match(/^country/)}
+    {:else if !reverse_only && addressLine.type.match(/^country/)}
       <PageLink page='search' params_hash={{ country: addressLine.localname }}>search by name</PageLink>
-    {:else if addressLine.type === 'postcode'}
+    {:else if !reverse_only && addressLine.type === 'postcode'}
       <PageLink page='search' params_hash={{ postalcode: addressLine.localname }}>search by name</PageLink>
     {/if}
   </td>

--- a/src/components/Error.svelte
+++ b/src/components/Error.svelte
@@ -14,6 +14,6 @@
   <div id="error" class="container-fluid alert-danger py-3 px-4">
     {error_message}
 
-    <button type="button" class="btn-close" aria-label="dismiss" on:click={dismiss_message}></button>
+    <button type="button" class="btn-close float-end" aria-label="dismiss" on:click={dismiss_message}></button>
   </div>
 {/if}

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -8,6 +8,7 @@
 
   $: view = $page.tab;
   $: page_title = Nominatim_Config.Page_Title;
+  $: reverse_only = Nominatim_Config.Reverse_Only;
 
   let map_lat;
   let map_lon;
@@ -67,7 +68,7 @@
     <div class="container-fluid">
       <!-- Brand -->
       <div class="navbar-brand">
-        <PageLink page="search">
+        <PageLink page={reverse_only ? 'reverse' : 'search'}>
           <img alt="logo" id="theme-logo" src="theme/logo.png" />
           <h1>{page_title}</h1>
         </PageLink>
@@ -79,9 +80,11 @@
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <!-- Left-aligned links -->
         <ul class="navbar-nav me-auto">
-          <li class="nav-item">
-            <PageLink page="search" extra_classes="nav-link {view === 'search' ? 'active' : ''}">Search</PageLink>
-          </li>
+          {#if !reverse_only}
+            <li class="nav-item">
+              <PageLink page="search" extra_classes="nav-link {view === 'search' ? 'active' : ''}">Search</PageLink>
+            </li>
+          {/if}
           <li class="nav-item">
             <ReverseLink lat={map_lat} lon={map_lon} extra_classes="nav-link {view === 'reverse' ? 'active' : ''}">Reverse</ReverseLink>
           </li>

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -16,16 +16,27 @@ export const page = writable();
  * the requested query parameters. It may also be omitted completely for a
  * link without query parameters.
  */
-const pagenames = ['search', 'reverse', 'details', 'deletable', 'polygons', 'status', 'about'];
+const default_pagename = Nominatim_Config.Reverse_Only ? 'reverse' : 'search';
+const pagenames = [
+  default_pagename,
+  'reverse',
+  'details',
+  'deletable',
+  'polygons',
+  'status',
+  'about'
+];
 
 export function refresh_page(pagename, params) {
   if (typeof pagename === 'undefined') {
     pagename = window.location.pathname.replace('.html', '').replace(/^.*\//, '');
 
-    if (!pagenames.includes(pagename)) pagename = 'search';
+    if (!pagenames.includes(pagename)) pagename = default_pagename;
 
     params = new URLSearchParams(window.location.search);
   } else {
+    if (!pagenames.includes(pagename)) pagename = default_pagename;
+
     if (typeof params === 'undefined') {
       params = new URLSearchParams();
     }

--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -69,6 +69,7 @@
       base_url = window.location.search;
     }
   }
+  $: reverse_only = Nominatim_Config.Reverse_Only;
 </script>
 
 <Header>
@@ -170,23 +171,13 @@
               {/each}
             {/if}
 
-            <tr class="all-columns"><td colspan="6"><h2>Keywords</h2></td></tr>
-            {#if api_request_params.keywords}
+            {#if !reverse_only}
+              <tr class="all-columns"><td colspan="6"><h2>Keywords</h2></td></tr>
+              {#if api_request_params.keywords}
 
-              {#if place_has_keywords(aPlace)}
-                <tr class="all-columns"><td colspan="6"><h3>Name Keywords</h3></td></tr>
-                {#each aPlace.keywords.name as keyword}
-                  <tr>
-                    <td>{formatKeywordToken(keyword.token)}</td>
-                    {#if keyword.id}
-                      <td>word id: {keyword.id}</td>
-                    {/if}
-                  </tr>
-                {/each}
-
-                {#if aPlace.keywords.address}
-                  <tr class="all-columns"><td colspan="6"><h3>Address Keywords</h3></td></tr>
-                  {#each aPlace.keywords.address as keyword}
+                {#if place_has_keywords(aPlace)}
+                  <tr class="all-columns"><td colspan="6"><h3>Name Keywords</h3></td></tr>
+                  {#each aPlace.keywords.name as keyword}
                     <tr>
                       <td>{formatKeywordToken(keyword.token)}</td>
                       {#if keyword.id}
@@ -194,17 +185,29 @@
                       {/if}
                     </tr>
                   {/each}
+
+                  {#if aPlace.keywords.address}
+                    <tr class="all-columns"><td colspan="6"><h3>Address Keywords</h3></td></tr>
+                    {#each aPlace.keywords.address as keyword}
+                      <tr>
+                        <td>{formatKeywordToken(keyword.token)}</td>
+                        {#if keyword.id}
+                          <td>word id: {keyword.id}</td>
+                        {/if}
+                      </tr>
+                    {/each}
+                  {/if}
+                {:else}
+                  <tr><td>Place has no keywords</td></tr>
                 {/if}
               {:else}
-                <tr><td>Place has no keywords</td></tr>
+                <tr>
+                  <td>
+                     <a class="btn btn-outline-secondary btn-sm"
+                      href="{base_url}&keywords=1">display keywords</a>
+                  </td>
+                </tr>
               {/if}
-            {:else}
-              <tr>
-                <td>
-                   <a class="btn btn-outline-secondary btn-sm"
-                    href="{base_url}&keywords=1">display keywords</a>
-                </td>
-              </tr>
             {/if}
 
             <tr class="all-columns"><td colspan="6"><h2>Parent Of</h2></td></tr>

--- a/test/_bootstrap.js
+++ b/test/_bootstrap.js
@@ -13,7 +13,7 @@ const testing_port = 9999; // this is the port all tests expect nominatim-ui to 
 // We can simulate that with a proxy.
 const use_proxy = !!process.env.API_ON_SAME_PORT;
 const static_port = use_proxy ? 9998 : 9999;
-
+const reverse_only = !!process.env.REVERSE_ONLY;
 
 // Methods to run at the start and end of the mocha testsuite run
 // https://mochajs.org/#global-setup-fixtures
@@ -28,6 +28,7 @@ exports.mochaGlobalSetup = async function () {
 
   fse.outputFile(workdir + '/theme/config.theme.js', `
 Nominatim_Config.Nominatim_API_Endpoint = '${api_endpoint}';
+Nominatim_Config.Reverse_Only = ${reverse_only};
   `);
 
 

--- a/test/config_reverse_only.js
+++ b/test/config_reverse_only.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+
+describe('Reverse Only', function () {
+  let page;
+
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  if (!process.env.REVERSE_ONLY) return;
+
+  describe('Redirect default pages', function () {
+    before(async function () {
+      page = await browser.newPage();
+      await page.goto('http://localhost:9999/search.html');
+    });
+
+    after(async function () {
+      await page.close();
+    });
+
+    it('should redirect to /reverse', async function () {
+      // await page.waitForSelector('footer');
+
+      let current_url = new URL(await page.url());
+      assert.deepStrictEqual(current_url.pathname, '/reverse.html');
+    });
+
+    it('no navigation link', async function () {
+      let nav_item = await page.$('nav ul li a[href="search.html"]');
+      assert.equal(nav_item, null);
+    });
+  });
+});

--- a/test/search.js
+++ b/test/search.js
@@ -3,6 +3,9 @@ const assert = require('assert');
 describe('Search Page', function () {
   let page;
 
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  if (process.env.REVERSE_ONLY) return;
+
   describe('No search', function () {
     before(async function () {
       page = await browser.newPage();


### PR DESCRIPTION
- search.html redirects to reverse.html
- 'search' removed from top navigation
- details page doesn't show 'display keywords' button
- extra tests, skip others when test suite called with REVERSE_ONLY=1

fixes https://github.com/osm-search/nominatim-ui/issues/163