### PR TITLE
detail page address list: better gray-out when line is not used

### DIFF
--- a/src/components/DetailsOneRow.svelte
+++ b/src/components/DetailsOneRow.svelte
@@ -38,8 +38,8 @@
 </tr>
 
 <style>
-  .notused {
-    color:#ddd;
+  .notused td {
+    color: #ccc;
   }
 
   td {


### PR DESCRIPTION
fixes https://github.com/osm-search/nominatim-ui/issues/175

![image](https://user-images.githubusercontent.com/3727288/154485032-41d2f4fb-9ced-4d4c-aee6-13006d40be55.png)
