### PR TITLE
Fix postcode documentation link

### DIFF
--- a/src/components/DetailsPostcodeHint.svelte
+++ b/src/components/DetailsPostcodeHint.svelte
@@ -52,7 +52,7 @@
   </button>
 
   Nightly calculated from nearby places having this postcode.
-  <a href="https://nominatim.org/release-docs/latest/develop/Postcodes/">Documentation</a>.
+  <a href="https://nominatim.org/release-docs/latest/admin/Maintenance/#updating-postcodes">Documentation</a>.
   You can search for those with an <a href={url} target="_blank">Overpass Turbo query</a>.
 </div>
 


### PR DESCRIPTION
The current link points to a page which doesn't exist since the 4.0.0 release: https://nominatim.org/release-docs/latest/develop/Postcodes/

https://nominatim.org/release-docs/latest/admin/Maintenance/#updating-postcodes looks like a valid replacement

