### PR TITLE
add Nominatim_Config.Map_Default_Bounds config value

### DIFF
--- a/dist/config.defaults.js
+++ b/dist/config.defaults.js
@@ -33,6 +33,7 @@ let Nominatim_Config = {
   Map_Default_Lat: 20.0,
   Map_Default_Lon: 0.0,
   Map_Default_Zoom: 2,
+  Map_Default_Bounds: null,
 
   // For what {x}, {y} etc stand for see
   // https://leafletjs.com/reference-1.9.1.html#tilelayer

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -28,6 +28,9 @@
       ],
       zoom: Nominatim_Config.Map_Default_Zoom
     });
+    if (typeof Nominatim_Config.Map_Default_Bounds !== 'undefined' && Nominatim_Config.Map_Default_Bounds) {
+      map.fitBounds(Nominatim_Config.Map_Default_Bounds);
+    }
 
     if (attribution && attribution.length) {
       L.control.attribution({ prefix: '<a href="https://leafletjs.com/">Leaflet</a>' }).addTo(map);


### PR DESCRIPTION
- use fitBounds() if this config value exists
- getting a bounding box might be easier in some use cases (instead of guessing at zoom value through external calculations)