### PR TITLE
Remove non-standard zoom levels

### DIFF
--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -142,10 +142,7 @@ export function zoomLevels() {
     /* 15 */ '',
     /* 16 */ 'Street',
     /* 17 */ '',
-    /* 18 */ 'Building',
-    /* 19 */ '',
-    /* 20 */ '',
-    /* 21 */ ''
+    /* 18 */ 'Building'
   ];
   return aZoomLevels;
 }


### PR DESCRIPTION
Nominatim only supports zoom level values up to 18. The others don't fail but work exactly the same as 18 and should not be presented in the zoom dropdown box.

I haven't tested this, in particular, if it breaks things somewhere else.