### PR TITLE
test-suite: remove httpbin HTTP calls, server is unreliable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 * version 3.2.13 - 2023-06-26
     * Reverse map: show search position (red circle) also when no search results
-    * text-suite: replace httpbin with beeceptor for mocking HTTP error codes
+    * test-suite: remove httpbin HTTP calls, server is unreliable
     * NPM package updates (Bootstrap 5.3, Leaflet 1.9.4)
 
 * version 3.2.12 - 2023-04-04

--- a/test/_bootstrap.js
+++ b/test/_bootstrap.js
@@ -64,6 +64,7 @@ Nominatim_Config.Reverse_Only = ${reverse_only};
     defaultViewport: { width: 1024, height: 768 },
     timeout: 10000,
     // latency: 1000,
+    headless: 'new',
     args: [
       '--user-agent=Nominatim UI test suite Mozilla/5.0 Gecko/20100101 HeadlessChrome/90.0'
     ]

--- a/test/api_errors.js
+++ b/test/api_errors.js
@@ -6,7 +6,7 @@ describe('Nominatim API errors', function () {
   describe('HTTP 503 - service unavailable', function () {
     before(async function () {
       page = await browser.newPage();
-      await page.goto('http://localhost:9999/search.html?q=london&mock_http_status=503');
+      await page.goto('http://localhost:9999/search.html?q=london&mock_api_error=fetch');
     });
 
     after(async function () {
@@ -17,7 +17,6 @@ describe('Nominatim API errors', function () {
       await page.waitForSelector('#error');
 
       let message = await page.$eval('#error', el => el.textContent);
-      assert.ok(message.includes('/status/503'));
       assert.ok(message.includes('Error fetching data from'));
     });
   });
@@ -25,7 +24,7 @@ describe('Nominatim API errors', function () {
   describe('HTTP 200 - JSON parsing fails', function () {
     before(async function () {
       page = await browser.newPage();
-      await page.goto('http://localhost:9999/search.html?q=london&mock_http_status=200');
+      await page.goto('http://localhost:9999/search.html?q=london&mock_api_error=parse');
     });
 
     after(async function () {
@@ -36,7 +35,6 @@ describe('Nominatim API errors', function () {
       await page.waitForSelector('#error');
 
       let message = await page.$eval('#error', el => el.textContent);
-      assert.ok(message.includes('/status/200'));
       assert.ok(message.includes('Error parsing JSON data from'));
     });
   });


### PR DESCRIPTION
httpbin.org was unreliable, beeceptor allows only 50 requests per day (on the free plan) and mockbin.org has no CORS headers setup. Now instead we treat the `fetch` response differently based on URL parameter. Another option would be to not fetch but create fetch response object and inspect those.