### PR TITLE
fix Svelte accessibility linter warnings, no more autofocus

### DIFF
--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -184,9 +184,9 @@
 
 <MapPosition />
 <div id="map" use:mapAction />
-<div id="show-map-position" class="leaflet-bar btn btn-sm btn-outline-secondary"
+<button id="show-map-position" class="leaflet-bar btn btn-sm btn-outline-secondary"
       on:click|stopPropagation={show_map_position_click}
->show map bounds</div>
+>show map bounds</button>
 
 <style>
   #map {

--- a/src/components/ResultsList.svelte
+++ b/src/components/ResultsList.svelte
@@ -59,7 +59,8 @@
       <div class="result"
            class:highlight={iResNum === iHighlightNum}
            data-position="{iResNum}"
-           on:click|stopPropagation={handleClick}>
+           on:click|stopPropagation={handleClick}
+           on:keypress|stopPropagation={handleClick}>
         <div style="float:right">
           <MapIcon aPlace={aResult} />
         </div>

--- a/src/components/SearchSection.svelte
+++ b/src/components/SearchSection.svelte
@@ -99,8 +99,7 @@
                type="text"
                class="form-control form-control-sm"
                placeholder="Search"
-               value="{api_request_params.q || ''}"
-               autofocus />
+               value="{api_request_params.q || ''}" />
       </div>
       <div class="col-auto">
         <button type="submit" class="btn btn-primary btn-sm mx-1">Search</button>

--- a/src/components/SearchSectionDetails.svelte
+++ b/src/components/SearchSectionDetails.svelte
@@ -30,8 +30,7 @@
       <input type="edit"
              class="form-control form-control-sm me-1"
              pattern="^[NWRnwr]?[0-9]+$|.*openstreetmap.*"
-             value="{api_request_params.osmtype || ''}{api_request_params.osmid || ''}{api_request_params.place_id || ''}"
-             autofocus />
+             value="{api_request_params.osmtype || ''}{api_request_params.osmid || ''}{api_request_params.place_id || ''}" />
       </div>
     <div class="col-auto">
       <button type="submit" class="btn btn-primary btn-sm">Show</button>

--- a/src/components/SearchSectionReverse.svelte
+++ b/src/components/SearchSectionReverse.svelte
@@ -49,15 +49,14 @@
            class="form-control form-control-sm d-inline"
            placeholder="latitude"
            pattern="^-?\d+(\.\d+)?$"
-           autofocus
            bind:value={lat}
            on:change={maybeSplitLatitude} />
   </div>
   <div class="col-auto">
-    <a id="switch-coords"
+    <button id="switch-coords"
        on:click|preventDefault|stopPropagation={() => gotoCoordinates(lon, lat)}
        class="btn btn-outline-secondary btn-sm"
-       title="switch lat and lon">&lt;&gt;</a>
+       title="switch lat and lon">&lt;&gt;</button>
   </div>
   <div class="col-auto">
     <label for="reverse-lon">lon</label>


### PR DESCRIPTION
During `yarn build` several warnings were displayed for months. Svelte includes accessibility linting by default, I think using https://github.com/jsx-eslint/eslint-plugin-jsx-a11y

3x `Plugin svelte: A11y: Avoid using autofocus`
3x `Plugin svelte: A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.`