### PR TITLE
Remove OSM type column from deletable and polygons page

### DIFF
--- a/src/pages/DeletablePage.svelte
+++ b/src/pages/DeletablePage.svelte
@@ -33,8 +33,7 @@
           <th>Place id</th>
           <th>Country Code</th>
           <th>Name</th>
-          <th>OSM id</th>
-          <th>OSM type</th>
+          <th>OSM object</th>
           <th>Class</th>
           <th>Type</th>
         </thead>
@@ -46,7 +45,6 @@
             <td>{polygon.name}</td>
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
             <td>{@html osmLink(polygon)}</td>
-            <td>{polygon.osm_type}</td>
             <td>{polygon.class}</td>
             <td>{polygon.type}</td>
           </tr>

--- a/src/pages/PolygonsPage.svelte
+++ b/src/pages/PolygonsPage.svelte
@@ -28,8 +28,7 @@
 
       <table class="table table-striped table-hover">
         <thead>
-          <th>OSM type</th>
-          <th>OSM id</th>
+          <th>OSM object</th>
           <th>Class</th>
           <th>Type</th>
           <th>Name</th>
@@ -41,7 +40,6 @@
         <tbody>
           {#each aPolygons as polygon}
             <tr>
-              <td>{polygon.osm_type}</td>
               <!-- eslint-disable-next-line svelte/no-at-html-tags -->
               <td>{@html osmLink(polygon)}</td>
               <td>{polygon.class}</td>


### PR DESCRIPTION
The type already appears in the ID link.