### PR TITLE
Add capability to use a WMS server as basemap

### DIFF
--- a/dist/config.defaults.js
+++ b/dist/config.defaults.js
@@ -41,6 +41,11 @@ let Nominatim_Config = {
   // For what {x}, {y} etc stand for see
   // https://leafletjs.com/reference-1.9.1.html#tilelayer
   Map_Tile_URL: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+  Map_isWMS: true,
+  WMSMap_Tile_URL: 'http://localhost:8080/geoserver/wms?',
+  WMSMap_layer: 'osm:osm',
+  WMSMap_format: 'image/png',
+  WMSMap_attribution: 'Local OSM server by Geoserver',
 
   // Can be text or HTML. To hide set to ''
   Map_Tile_Attribution: '<a href="https://osm.org/copyright">OpenStreetMap contributors</a>'

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -37,9 +37,18 @@
       L.control.attribution({ prefix: '<a href="https://leafletjs.com/">Leaflet</a>' }).addTo(map);
     }
 
-    L.tileLayer(Nominatim_Config.Map_Tile_URL, {
-      attribution: attribution
-    }).addTo(map);
+    if (Nominatim_Config.Map_isWMS) {
+      L.tileLayer.wms(Nominatim_Config.WMSMap_Tile_URL, {
+          layers: Nominatim_Config.WMSMap_layer,
+          format: Nominatim_Config.WMSMap_format,
+          transparent: true,
+          attribution: Nominatim_Config.WMSMap_attribution
+      }).addTo(map);
+    } else {
+      L.tileLayer(Nominatim_Config.Map_Tile_URL, {
+        attribution: attribution
+      }).addTo(map);
+    }
 
     if (display_minimap) {
       let osm2 = new L.TileLayer(Nominatim_Config.Map_Tile_URL, {


### PR DESCRIPTION
I would like to offer next modifications which allows to extent the basemap capabilities in the nominatim-ui tool, to use a WMS tile based service.
I have applied that in context of this project:
https://github.com/geotekne-argentina/osm-nominatim-geoserver-postgis

(hope you find it useful -it was for me- since I expected to show that all the data can be consumed from local resources).
