### PR TITLE
Reverse page: update lat/lon test

### DIFF
--- a/src/pages/ReversePage.svelte
+++ b/src/pages/ReversePage.svelte
@@ -24,7 +24,7 @@
       format: 'jsonv2'
     };
 
-    if (api_request_params.lat || api_request_params.lat) {
+    if (api_request_params.lat && api_request_params.lon) {
 
       fetch_from_api('reverse', api_request_params, function (data) {
         position_marker = [api_request_params.lat, api_request_params.lon];


### PR DESCRIPTION
The current test of the reverse geocoding parameters is only based on the lat parameter.

It means that even if the lon input/parameter is absent, the API (reverse endpoint) is fetched and returns an error: {"error":{"code":400,"message":"Parameter 'lon' missing."}}

Here is an example:
<https://nominatim.openstreetmap.org/ui/reverse.html?lat=65&zoom=18>

The purpose of this PR is to add the lon parameter to the test.