### PR TITLE
Remove click search (reverse) propagation on search page

### DIFF
--- a/src/components/SearchSectionReverse.svelte
+++ b/src/components/SearchSectionReverse.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { onDestroy } from 'svelte';
   import UrlSubmitForm from '../components/UrlSubmitForm.svelte';
 
   import { zoomLevels } from '../lib/helpers.js';
@@ -19,7 +20,7 @@
     refresh_page('reverse', params);
   }
 
-  map_store.subscribe(map => {
+  const unsubscribe = map_store.subscribe(map => {
     if (map) {
       map.on('click', (e) => {
         let coords = e.latlng.wrap();
@@ -40,6 +41,8 @@
   function set_api_param(e) {
     document.querySelector('input[name=' + e.target.dataset.apiParam + ']').value = e.target.value;
   }
+
+  onDestroy(unsubscribe);
 </script>
 
 <UrlSubmitForm page="reverse">


### PR DESCRIPTION
**Description**
Once the reverse page has been opened, a map click will produce a reverse search. This is propagated as well on the search page. A click on the map will reopen the reverse page.

**How to reproduce**
- Access the reverse page, e.g. https://nominatim.openstreetmap.org/ui/reverse.html
- Click on the search page link (search.html)
- Click on the map
- The reverse page will be automatically reopened with the coordinates that were clicked.

**PR**
This PR removes the click behaviour by removing it from the map store subscription when the reverse page is closed.

**Tests**
Integration test suite: passed
Syntax linter: passed