### PR TITLE
Svelte v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,46 +1,49 @@
 {
-  "name": "nominatim-ui",
-  "description": "Debug web interface for Nominatim geocoder",
-  "version": "3.5.3",
-  "license": "GPL-2.0",
-  "scripts": {
-    "build": "rollup -c",
-    "dev": "rollup -c -w",
-    "lint": "eslint --quiet *.js src/ test/",
-    "lint:fix": "eslint --fix *.js src/ test/",
-    "test": "rollup -c && mocha --recursive test/",
-    "start": "static-server dist"
-  },
-  "devDependencies": {
-    "@eslint/eslintrc": "^3.1.0",
-    "@eslint/js": "^9.12.0",
-    "@rollup/plugin-commonjs": "^28.0",
-    "@rollup/plugin-node-resolve": "^15.0",
-    "eslint": "^9.0",
-    "eslint-config-airbnb-base": "^15.0",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-mocha": "^10.0",
-    "eslint-plugin-svelte": "^2.13",
-    "fs-extra": "^11.0.0",
-    "globals": "^15.11.0",
-    "http": "^0.0.1-security",
-    "http-proxy": "^1.18.1",
-    "mocha": "^10.0",
-    "puppeteer": "^23.0",
-    "rollup": "^4.22.4",
-    "rollup-plugin-css-only": "^4.3.0",
-    "rollup-plugin-livereload": "^2.0.0",
-    "rollup-plugin-svelte": "^7.0.0",
-    "rollup-plugin-terser": "^7.0.0",
-    "static-server": "^2.2.1",
-    "svelte": "^4.2"
-  },
-  "dependencies": {
-    "bootstrap": "^5.0.0",
-    "escape-html": "^1.0.3",
-    "leaflet": "1.9.4",
-    "leaflet-minimap": "^3.6.1",
-    "timeago.js": "^4.0.2"
-  },
-  "type": "module"
+    "name": "nominatim-ui",
+    "description": "Debug web interface for Nominatim geocoder",
+    "version": "3.5.3",
+    "license": "GPL-2.0",
+    "scripts":
+    {
+        "build": "rollup -c",
+        "dev": "rollup -c -w",
+        "lint": "eslint --quiet *.js src/ test/",
+        "lint:fix": "eslint --fix *.js src/ test/",
+        "test": "rollup -c && mocha --recursive test/",
+        "start": "static-server dist"
+    },
+    "devDependencies":
+    {
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "^9.12.0",
+        "@rollup/plugin-commonjs": "^28.0",
+        "@rollup/plugin-node-resolve": "^15.0",
+        "eslint": "^9.0",
+        "eslint-config-airbnb-base": "^15.0",
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-mocha": "^10.0",
+        "eslint-plugin-svelte": "^2.13",
+        "fs-extra": "^11.0.0",
+        "globals": "^15.11.0",
+        "http": "^0.0.1-security",
+        "http-proxy": "^1.18.1",
+        "mocha": "^10.0",
+        "puppeteer": "^23.0",
+        "rollup": "^4.22.4",
+        "rollup-plugin-css-only": "^4.3.0",
+        "rollup-plugin-livereload": "^2.0.0",
+        "rollup-plugin-svelte": "^7.0.0",
+        "rollup-plugin-terser": "^7.0.0",
+        "static-server": "^2.2.1",
+        "svelte": "^5.0.0"
+    },
+    "dependencies":
+    {
+        "bootstrap": "^5.0.0",
+        "escape-html": "^1.0.3",
+        "leaflet": "1.9.4",
+        "leaflet-minimap": "^3.6.1",
+        "timeago.js": "^4.0.2"
+    },
+    "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -1,49 +1,46 @@
 {
-    "name": "nominatim-ui",
-    "description": "Debug web interface for Nominatim geocoder",
-    "version": "3.5.3",
-    "license": "GPL-2.0",
-    "scripts":
-    {
-        "build": "rollup -c",
-        "dev": "rollup -c -w",
-        "lint": "eslint --quiet *.js src/ test/",
-        "lint:fix": "eslint --fix *.js src/ test/",
-        "test": "rollup -c && mocha --recursive test/",
-        "start": "static-server dist"
-    },
-    "devDependencies":
-    {
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "^9.12.0",
-        "@rollup/plugin-commonjs": "^28.0",
-        "@rollup/plugin-node-resolve": "^15.0",
-        "eslint": "^9.0",
-        "eslint-config-airbnb-base": "^15.0",
-        "eslint-plugin-import": "^2.22.1",
-        "eslint-plugin-mocha": "^10.0",
-        "eslint-plugin-svelte": "^2.13",
-        "fs-extra": "^11.0.0",
-        "globals": "^15.11.0",
-        "http": "^0.0.1-security",
-        "http-proxy": "^1.18.1",
-        "mocha": "^10.0",
-        "puppeteer": "^23.0",
-        "rollup": "^4.22.4",
-        "rollup-plugin-css-only": "^4.3.0",
-        "rollup-plugin-livereload": "^2.0.0",
-        "rollup-plugin-svelte": "^7.0.0",
-        "rollup-plugin-terser": "^7.0.0",
-        "static-server": "^2.2.1",
-        "svelte": "^5.0.0"
-    },
-    "dependencies":
-    {
-        "bootstrap": "^5.0.0",
-        "escape-html": "^1.0.3",
-        "leaflet": "1.9.4",
-        "leaflet-minimap": "^3.6.1",
-        "timeago.js": "^4.0.2"
-    },
-    "type": "module"
+  "name": "nominatim-ui",
+  "description": "Debug web interface for Nominatim geocoder",
+  "version": "3.5.3",
+  "license": "GPL-2.0",
+  "scripts": {
+    "build": "rollup -c",
+    "dev": "rollup -c -w",
+    "lint": "eslint --quiet *.js src/ test/",
+    "lint:fix": "eslint --fix *.js src/ test/",
+    "test": "rollup -c && mocha --recursive test/",
+    "start": "static-server dist"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
+    "@eslint/js": "^9.12.0",
+    "@rollup/plugin-commonjs": "^28.0",
+    "@rollup/plugin-node-resolve": "^15.0",
+    "eslint": "^9.0",
+    "eslint-config-airbnb-base": "^15.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-mocha": "^10.0",
+    "eslint-plugin-svelte": "^2.13",
+    "fs-extra": "^11.0.0",
+    "globals": "^15.11.0",
+    "http": "^0.0.1-security",
+    "http-proxy": "^1.18.1",
+    "mocha": "^10.0",
+    "puppeteer": "^23.0",
+    "rollup": "^4.22.4",
+    "rollup-plugin-css-only": "^4.3.0",
+    "rollup-plugin-livereload": "^2.0.0",
+    "rollup-plugin-svelte": "^7.0.0",
+    "rollup-plugin-terser": "^7.0.0",
+    "static-server": "^2.2.1",
+    "svelte": "^5.0.0"
+  },
+  "dependencies": {
+    "bootstrap": "^5.0.0",
+    "escape-html": "^1.0.3",
+    "leaflet": "1.9.4",
+    "leaflet-minimap": "^3.6.1",
+    "timeago.js": "^4.0.2"
+  },
+  "type": "module"
 }

--- a/src/components/DetailsPostcodeHint.svelte
+++ b/src/components/DetailsPostcodeHint.svelte
@@ -51,7 +51,7 @@
           class="btn-close float-end m-1"
           aria-label="Close"
           on:click|stopPropagation={closeHint}
-  />
+  ></button>
   <p>
     Nightly calculated from nearby places having this postcode.
     <a href="https://nominatim.org/release-docs/latest/admin/Maintenance/#updating-postcodes">

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -186,7 +186,7 @@
 </script>
 
 <MapPosition />
-<div id="map" use:mapAction />
+<div id="map" use:mapAction></div>
 <button id="show-map-position" class="leaflet-bar btn btn-sm btn-outline-secondary"
       on:click|stopPropagation={show_map_position_click}
 >show map bounds</button>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,8 @@
+import { mount } from 'svelte';
 import App from './App.svelte';
 
-const app = new App({ // eslint-disable-line no-unused-vars
+const app = mount(App, { // eslint-disable-line no-unused-vars
   target: document.body
 });
+
+export default app;

--- a/src/pages/DeletablePage.svelte
+++ b/src/pages/DeletablePage.svelte
@@ -30,12 +30,14 @@
 
       <table class="table table-striped table-hover">
         <thead>
-          <th>Place id</th>
-          <th>Country Code</th>
-          <th>Name</th>
-          <th>OSM object</th>
-          <th>Class</th>
-          <th>Type</th>
+          <tr>
+            <th>Place id</th>
+            <th>Country Code</th>
+            <th>Name</th>
+            <th>OSM object</th>
+            <th>Class</th>
+            <th>Type</th>
+          </tr>
         </thead>
         <tbody>
           {#each aPolygons as polygon}

--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -242,7 +242,7 @@
                 {/each}
 
                 {#if Object.keys(aPlace.hierarchy) > 500}
-                  <p>There are more child objects which are not shown.</p>
+                  <tr><td><p>There are more child objects which are not shown.</p></td></tr>
                 {/if}
               {:else}
                 <tr><td>Place is not parent of other places</td></tr>

--- a/src/pages/PolygonsPage.svelte
+++ b/src/pages/PolygonsPage.svelte
@@ -28,14 +28,16 @@
 
       <table class="table table-striped table-hover">
         <thead>
-          <th>OSM object</th>
-          <th>Class</th>
-          <th>Type</th>
-          <th>Name</th>
-          <th>Country Code</th>
-          <th>Error message</th>
-          <th>Updated</th>
-          <th></th>
+          <tr>
+            <th>OSM object</th>
+            <th>Class</th>
+            <th>Type</th>
+            <th>Name</th>
+            <th>Country Code</th>
+            <th>Error message</th>
+            <th>Updated</th>
+            <th></th>
+          </tr>
         </thead>
         <tbody>
           {#each aPolygons as polygon}

--- a/test/details.js
+++ b/test/details.js
@@ -155,7 +155,7 @@ describe('Details Page', function () {
     it('should display No Name, no keywords, no hierarchy', async function () {
       let page_content = await page.$eval('body', el => el.textContent);
 
-      assert.ok(page_content.includes('Name No Name'));
+      assert.ok(page_content.includes('NameNo Name'));
       if (!process.env.REVERSE_ONLY) {
         assert.ok(page_content.includes('Place has no keywords'));
       }

--- a/test/search.js
+++ b/test/search.js
@@ -41,18 +41,24 @@ describe('Search Page', function () {
       assert.strictEqual(await map_pos_handle.evaluate(node => node.style.display), 'block');
 
       let map_pos_details = await page.$eval('#map-position-inner', el => el.textContent);
-      map_pos_details = map_pos_details.split(' \n');
-
-      let map_center_coor = map_pos_details[0]
+      map_pos_details = map_pos_details.split('  ');
+      // [
+      //   'map center: 20.00000,0.00000 view on osm.org',
+      //   'map zoom: 2',
+      //   'viewbox: -131.48438,69.16256,131.48438,-48.69096',
+      //   'last click:',
+      //   ' mouse position: 65.69612,103.71094'
+      // ]
+      let map_center_coords = map_pos_details[0]
         .split('map center: ')[1].split(' view')[0].split(',');
       let map_zoom = map_pos_details[1].split('map zoom: ')[1];
       let map_viewbox = map_pos_details[2].split('viewbox: ')[1].split(',');
       let last_click = map_pos_details[3].split('last click: ')[1];
 
-      assert.deepStrictEqual(map_center_coor.length, 2);
+      assert.deepStrictEqual(map_center_coords.length, 2);
       assert.ok(map_zoom);
       assert.deepStrictEqual(map_viewbox.length, 4);
-      assert.deepStrictEqual(last_click, 'undefined');
+      assert.deepStrictEqual(last_click, undefined);
 
       await page.click('#map-position-close a');
       assert.strictEqual(await map_pos_handle.evaluate(node => node.style.display), 'none');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@ampproject/remapping@^2.2.1":
+"@ampproject/remapping@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
   integrity sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==
@@ -146,7 +146,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
-"@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
@@ -299,7 +299,7 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
   integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
-"@types/estree@*", "@types/estree@1.0.6", "@types/estree@^1.0.0", "@types/estree@^1.0.1", "@types/estree@^1.0.6":
+"@types/estree@*", "@types/estree@1.0.6", "@types/estree@^1.0.0", "@types/estree@^1.0.1", "@types/estree@^1.0.5", "@types/estree@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
@@ -338,7 +338,12 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.10.0, acorn@^8.12.0, acorn@^8.8.2, acorn@^8.9.0:
+acorn-typescript@^1.4.13:
+  version "1.4.13"
+  resolved "https://registry.yarnpkg.com/acorn-typescript/-/acorn-typescript-1.4.13.tgz#5f851c8bdda0aa716ffdd5f6ac084df8acc6f5ea"
+  integrity sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==
+
+acorn@^8.12.0, acorn@^8.12.1, acorn@^8.8.2, acorn@^8.9.0:
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.13.0.tgz#2a30d670818ad16ddd6a35d3842dacec9e5d7ca3"
   integrity sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==
@@ -407,7 +412,7 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aria-query@^5.3.0:
+aria-query@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
@@ -492,7 +497,7 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axobject-query@^4.0.0:
+axobject-query@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
@@ -696,17 +701,6 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-code-red@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/code-red/-/code-red-1.0.4.tgz#59ba5c9d1d320a4ef795bc10a28bd42bfebe3e35"
-  integrity sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==
-  dependencies:
-    "@jridgewell/sourcemap-codec" "^1.4.15"
-    "@types/estree" "^1.0.1"
-    acorn "^8.10.0"
-    estree-walker "^3.0.3"
-    periscopic "^3.1.0"
-
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -769,14 +763,6 @@ cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-css-tree@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
-  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
-  dependencies:
-    mdn-data "2.0.30"
-    source-map-js "^1.0.1"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -1202,6 +1188,11 @@ eslint@^9.0:
     optionator "^0.9.3"
     text-table "^0.2.0"
 
+esm-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esm-env/-/esm-env-1.0.0.tgz#b124b40b180711690a4cb9b00d16573391950413"
+  integrity sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==
+
 espree@^10.0.1, espree@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-10.2.0.tgz#f4bcead9e05b0615c968e85f83816bc386a45df6"
@@ -1232,6 +1223,14 @@ esquery@^1.5.0:
   dependencies:
     estraverse "^5.1.0"
 
+esrap@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/esrap/-/esrap-1.2.2.tgz#b9e3afee3f12238563a763b7fa86220de2c53203"
+  integrity sha512-F2pSJklxx1BlQIQgooczXCPHmcWpn6EsP5oo73LQfonG9fIlIENQ8vMmfGXeojP9MrkzUNAfyU5vdFlR9shHAw==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+    "@types/estree" "^1.0.1"
+
 esrecurse@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
@@ -1248,13 +1247,6 @@ estree-walker@^2.0.1, estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
-
-estree-walker@^3.0.0, estree-walker@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
-  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
-  dependencies:
-    "@types/estree" "^1.0.0"
 
 esutils@^2.0.2, esutils@^2.0.3:
   version "2.0.3"
@@ -1762,7 +1754,7 @@ is-reference@1.2.1:
   dependencies:
     "@types/estree" "*"
 
-is-reference@^3.0.0, is-reference@^3.0.1:
+is-reference@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-3.0.2.tgz#154747a01f45cd962404ee89d43837af2cba247c"
   integrity sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==
@@ -1979,17 +1971,12 @@ lru-cache@^7.14.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
-magic-string@^0.30.3, magic-string@^0.30.4:
+magic-string@^0.30.11, magic-string@^0.30.3:
   version "0.30.12"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.12.tgz#9eb11c9d072b9bcb4940a5b2c2e1a217e4ee1a60"
   integrity sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
-
-mdn-data@2.0.30:
-  version "2.0.30"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
-  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -2236,15 +2223,6 @@ pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
-
-periscopic@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/periscopic/-/periscopic-3.1.0.tgz#7e9037bf51c5855bd33b48928828db4afa79d97a"
-  integrity sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==
-  dependencies:
-    "@types/estree" "^1.0.0"
-    estree-walker "^3.0.0"
-    is-reference "^3.0.0"
 
 picocolors@^1.0.0, picocolors@^1.1.0:
   version "1.1.1"
@@ -2601,7 +2579,7 @@ socks@^2.8.3:
     ip-address "^9.0.5"
     smart-buffer "^4.2.0"
 
-source-map-js@^1.0.1, source-map-js@^1.2.1:
+source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -2749,25 +2727,24 @@ svelte-eslint-parser@^0.42.0:
     postcss "^8.4.39"
     postcss-scss "^4.0.9"
 
-svelte@^4.2:
-  version "4.2.19"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-4.2.19.tgz#4e6e84a8818e2cd04ae0255fcf395bc211e61d4c"
-  integrity sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==
+svelte@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-5.0.3.tgz#093663a1c71c887e592fb34b4886da9105b6a9b7"
+  integrity sha512-i8DopbAPRP9iaR3qqe++LPv4povQRshSseH3kSrzI4URZ9/7OTt3vCJPBp+5ACRQDik0S/tM1ZRA6EW/sGcKfw==
   dependencies:
-    "@ampproject/remapping" "^2.2.1"
-    "@jridgewell/sourcemap-codec" "^1.4.15"
-    "@jridgewell/trace-mapping" "^0.3.18"
-    "@types/estree" "^1.0.1"
-    acorn "^8.9.0"
-    aria-query "^5.3.0"
-    axobject-query "^4.0.0"
-    code-red "^1.0.3"
-    css-tree "^2.3.1"
-    estree-walker "^3.0.3"
-    is-reference "^3.0.1"
+    "@ampproject/remapping" "^2.3.0"
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@types/estree" "^1.0.5"
+    acorn "^8.12.1"
+    acorn-typescript "^1.4.13"
+    aria-query "^5.3.1"
+    axobject-query "^4.1.0"
+    esm-env "^1.0.0"
+    esrap "^1.2.2"
+    is-reference "^3.0.2"
     locate-character "^3.0.0"
-    magic-string "^0.30.4"
-    periscopic "^3.1.0"
+    magic-string "^0.30.11"
+    zimmerframe "^1.1.2"
 
 tar-fs@^3.0.6:
   version "3.0.6"
@@ -3078,6 +3055,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zimmerframe@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/zimmerframe/-/zimmerframe-1.1.2.tgz#5b75f1fa83b07ae2a428d51e50f58e2ae6855e5e"
+  integrity sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==
 
 zod@3.23.8:
   version "3.23.8"


### PR DESCRIPTION
Following https://svelte-5-preview.vercel.app/docs/breaking-changes the App initialization changed and some trouble with whitespace parsing in tests.

Svelte v5 aims to be compatible with version 4 so it can handle old-style components. Currently doesn't even print deprecation notices. At some point we'll need to upgrade the components and stores I guess. https://svelte-5-preview.vercel.app/docs/old-vs-new