### PR TITLE
Github Actions: add Google Chrome action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,21 @@ on:
 
 jobs:
   build:
-
     name: Build
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
+
+      - uses: browser-actions/setup-chrome@v1
+      - run: chrome --version
+
+      - name: Disable AppArmor User Namespace Restrictions for Chromium developer version
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
Github Actions started defaulting `ubuntu-latest` to Ubuntu-24 (the rollout is over weeks so it seems random which version gets installed, quite confusing). Google Chrome browser started complaining about not being in a sandbox. Installing it using an action (https://github.com/browser-actions/setup-chrome) and helped.