### PR TITLE
Init color toggler each page

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,6 @@
 <script>
   import 'bootstrap/dist/css/bootstrap.css';
   import 'bootstrap/dist/js/bootstrap.bundle.js';
-  import './color-mode-toggler.js';
 
   import { page, refresh_page } from './lib/stores.js';
 

--- a/src/color-mode-toggler.js
+++ b/src/color-mode-toggler.js
@@ -6,7 +6,8 @@
  * Licensed under the Creative Commons Attribution 3.0 Unported License.
  */
 
-(() => {
+export function initColorToggler() {
+
   const getStoredTheme = () => localStorage.getItem('theme')
   const setStoredTheme = theme => localStorage.setItem('theme', theme)
 
@@ -64,17 +65,15 @@
     }
   })
 
-  window.addEventListener('DOMContentLoaded', () => {
-    showActiveTheme(getPreferredTheme())
+  showActiveTheme(getPreferredTheme())
 
-    document.querySelectorAll('[data-bs-theme-value]')
-      .forEach(toggle => {
-        toggle.addEventListener('click', () => {
-          const theme = toggle.getAttribute('data-bs-theme-value')
-          setStoredTheme(theme)
-          setTheme(theme)
-          showActiveTheme(theme, true)
-        })
+  document.querySelectorAll('[data-bs-theme-value]')
+    .forEach(toggle => {
+      toggle.addEventListener('click', () => {
+        const theme = toggle.getAttribute('data-bs-theme-value')
+        setStoredTheme(theme)
+        setTheme(theme)
+        showActiveTheme(theme, true)
       })
-  })
-})()
+    })
+}

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -3,8 +3,9 @@
   import ReverseLink from './ReverseLink.svelte';
   import LastUpdated from './LastUpdated.svelte';
   import Error from './Error.svelte';
-
+  import { onMount } from 'svelte';
   import { map_store, page } from '../lib/stores.js';
+  import { initColorToggler } from '../color-mode-toggler.js';
 
   let { subheader } = $props();
 
@@ -25,6 +26,8 @@
   });
 
   page.subscribe(pg => { view = pg.tab; });
+
+  onMount(initColorToggler);
 </script>
 
 <style>

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -7,6 +7,7 @@ export const last_api_request_url_store = writable();
 export const error_store = writable();
 export const page = writable();
 
+
 /**
  * Update the global page state.
  *


### PR DESCRIPTION
Fixes https://github.com/osm-search/nominatim-ui/pull/276#issuecomment-3173605485

The color toggler dropdown is getting re-added (the component remounted) after each page refresh. Thus the `$link.addEventListener` need to be called again.