### PR TITLE
Replace map store with global map state

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,6 +2,7 @@
   import 'bootstrap/dist/css/bootstrap.css';
   import 'bootstrap/dist/js/bootstrap.bundle.js';
 
+  import { onMount } from 'svelte';
   import { page, refresh_page } from './lib/stores.js';
 
   import Footer from './components/Footer.svelte';
@@ -13,7 +14,15 @@
   import StatusPage from './pages/StatusPage.svelte';
   import AboutPage from './pages/AboutPage.svelte';
 
-  $: view = $page.tab;
+  let view = $state();
+
+  onMount(() => {
+    page.subscribe((pageinfo) => {
+      if (pageinfo.tab !== view) {
+        view = pageinfo.tab;
+      }
+    })
+  });
 
   refresh_page();
 </script>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -4,7 +4,8 @@
   import LastUpdated from './LastUpdated.svelte';
   import Error from './Error.svelte';
   import { onMount } from 'svelte';
-  import { map_store, page } from '../lib/stores.js';
+  import { page } from '../lib/stores.js';
+  import { mapState } from '../state/MapState.svelte.js';
   import { initColorToggler } from '../color-mode-toggler.js';
 
   let { subheader } = $props();
@@ -13,17 +14,6 @@
   const reverse_only = Nominatim_Config.Reverse_Only;
 
   let view = $state();
-  let map_lat = $state();
-  let map_lon = $state();
-
-  map_store.subscribe(map => {
-    if (!map) return;
-
-    map.on('move', function () {
-      map_lat = map.getCenter().lat.toFixed(5);
-      map_lon = map.getCenter().lng.toFixed(5);
-    });
-  });
 
   page.subscribe(pg => { view = pg.tab; });
 
@@ -104,8 +94,8 @@
             </li>
           {/if}
           <li class="nav-item">
-            <ReverseLink lat={map_lat}
-                         lon={map_lon}
+            <ReverseLink lat={mapState.center.lat}
+                         lon={mapState.center.lng}
                          text="Reverse"
                          extra_classes="nav-link {view === 'reverse' ? 'active' : ''}" />
           </li>

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -54,12 +54,6 @@
       new L.Control.MiniMap(osm2, { toggleDisplay: true }).addTo(map);
     }
 
-    const MapPositionControl = L.Control.extend({
-      options: { position: 'topright' },
-      onAdd: () => { return document.getElementById('show-map-position'); }
-    });
-    map.addControl(new MapPositionControl());
-
     return map;
   }
 
@@ -183,31 +177,15 @@
 
   $effect(() => { setMapData(current_result); });
 
-  function show_map_position_click(e) {
-    e.stopPropagation();
-    e.target.style.display = 'none';
-    document.getElementById('map-position').style.display = 'block';
-  }
 </script>
 
-<MapPosition />
 <div id="map" use:mapAction></div>
-<button id="show-map-position" class="leaflet-bar btn btn-sm btn-outline-secondary"
-      onclick={show_map_position_click}
->show map bounds</button>
+<MapPosition />
 
 <style>
   #map {
     height: 100%;
     background:#eee;
-  }
-
-  .btn-outline-secondary {
-    background-color: white;
-  }
-
-  .btn-outline-secondary:hover {
-    color: #111;
   }
 
   @media (max-width: 768px) {

--- a/src/components/MapPosition.svelte
+++ b/src/components/MapPosition.svelte
@@ -1,14 +1,10 @@
 <script>
-  let { center,
-        zoom,
-        viewboxStr,
-        lastClick,
-        mousePos } = $props();
+  import { mapState } from '../state/MapState.svelte.js';
 
   let visible = $state(false);
 
   const view_on_osm_link = $derived(
-      `https://openstreetmap.org/#map=${zoom}/${center.lat.toFixed(5)}/${center.lng.toFixed(5)}`
+      `https://openstreetmap.org/#map=${mapState.zoom}/${mapState.center.lat.toFixed(5)}/${mapState.center.lng.toFixed(5)}`
   );
 
   function coordToString(c) {
@@ -19,21 +15,24 @@
 <div id="map-position">
 {#if visible}
   <div id="map-position-inner">
-    map center: {coordToString(center)}
+    map center: {coordToString(mapState.center)}
     <a target="_blank" rel="noreferrer" href="{view_on_osm_link}">view on osm.org</a>
     <br>
-    map zoom: {zoom}
+    map zoom: {mapState.zoom}
     <br>
-    viewbox: {viewboxStr}
+    viewbox: {mapState.viewboxStr}
     <br>
-    last click: {coordToString(lastClick)}
+    last click: {coordToString(mapState.lastClick)}
     <br>
-    mouse position: {coordToString(mousePos)}
+    mouse position: {coordToString(mapState.mousePos)}
   </div>
   <div id="map-position-close"><a href="#hide" onclick={() => visible = false}>hide</a></div>
 {:else}
-<button class="btn btn-sm btn-outline-secondary" onclick={() => visible = true}
->show map bounds</button>
+<button id="show-map-position"
+        class="btn btn-sm btn-outline-secondary"
+        onclick={() => visible = true}>
+  show map bounds
+</button>
 {/if}
 </div>
 

--- a/src/components/MapPosition.svelte
+++ b/src/components/MapPosition.svelte
@@ -1,94 +1,34 @@
 <script>
-
-  import { map_store } from '../lib/stores.js';
+  let { center,
+        zoom,
+        viewboxStr,
+        lastClick,
+        mousePos } = $props();
 
   let visible = $state(false);
-  let map_center = $state();
-  let map_zoom = $state();
-  let map_viewbox = $state();
-  let view_on_osm_link = $state();
-  let last_click = $state();
-  let mouse_position = $state();
 
-  function map_link_to_osm(map) {
-    var zoom = map.getZoom();
-    var lat = map.getCenter().lat.toFixed(5);
-    var lng = map.getCenter().lng.toFixed(5);
-    return 'https://openstreetmap.org/#map=' + zoom + '/' + lat + '/' + lng;
+  const view_on_osm_link = $derived(
+      `https://openstreetmap.org/#map=${zoom}/${center.lat.toFixed(5)}/${center.lng.toFixed(5)}`
+  );
+
+  function coordToString(c) {
+    return c ? `${c.lat.toFixed(5)},${c.lng.toFixed(5)}` : '-';
   }
-
-  function map_viewbox_as_string(map) {
-    var bounds = map.getBounds();
-    var west = bounds.getWest();
-    var east = bounds.getEast();
-
-    if ((east - west) >= 360) { // covers more than whole planet
-      west = map.getCenter().lng - 179.999;
-      east = map.getCenter().lng + 179.999;
-    }
-    east = L.latLng(77, east).wrap().lng;
-    west = L.latLng(77, west).wrap().lng;
-
-    return [
-      west.toFixed(5), // left
-      bounds.getNorth().toFixed(5), // top
-      east.toFixed(5), // right
-      bounds.getSouth().toFixed(5) // bottom
-    ].join(',');
-  }
-
-  function display_map_position(map, mouse_lat_lng) {
-    map_center = map.getCenter().lat.toFixed(5) + ',' + map.getCenter().lng.toFixed(5);
-    view_on_osm_link = map_link_to_osm(map);
-    map_zoom = map.getZoom();
-    map_viewbox = map_viewbox_as_string(map);
-    mouse_position = '-';
-    if (mouse_lat_lng) {
-      mouse_position = [mouse_lat_lng.lat.toFixed(5), mouse_lat_lng.lng.toFixed(5)].join(',');
-    }
-  }
-
-
-  map_store.subscribe(map => {
-    if (!map) return;
-
-    map.on('move', function () {
-      display_map_position(map);
-      // update_viewbox_field();
-    });
-
-    map.on('mousemove', function (e) {
-      display_map_position(map, e.latlng);
-    });
-
-    map.on('click', function (e) {
-      const last_click_latlng = e.latlng;
-      if (last_click_latlng) {
-        last_click = [last_click_latlng.lat.toFixed(5), last_click_latlng.lng.toFixed(5)].join(',');
-      }
-      display_map_position(map);
-    });
-
-    map.on('load', function () {
-      display_map_position(map);
-    });
-  });
-
 </script>
 
 <div id="map-position">
 {#if visible}
   <div id="map-position-inner">
-    map center: {map_center}
+    map center: {coordToString(center)}
     <a target="_blank" rel="noreferrer" href="{view_on_osm_link}">view on osm.org</a>
     <br>
-    map zoom: {map_zoom}
+    map zoom: {zoom}
     <br>
-    viewbox: {map_viewbox}
+    viewbox: {viewboxStr}
     <br>
-    last click: {last_click}
+    last click: {coordToString(lastClick)}
     <br>
-    mouse position: {mouse_position}
+    mouse position: {coordToString(mousePos)}
   </div>
   <div id="map-position-close"><a href="#hide" onclick={() => visible = false}>hide</a></div>
 {:else}

--- a/src/components/MapPosition.svelte
+++ b/src/components/MapPosition.svelte
@@ -2,6 +2,7 @@
 
   import { map_store } from '../lib/stores.js';
 
+  let visible = $state(false);
   let map_center = $state();
   let map_zoom = $state();
   let map_viewbox = $state();
@@ -73,14 +74,10 @@
     });
   });
 
-  function handleHideClick() {
-    document.getElementById('map-position').style.display = 'none';
-    document.getElementById('show-map-position').style.display = 'block';
-  }
-
 </script>
 
 <div id="map-position">
+{#if visible}
   <div id="map-position-inner">
     map center: {map_center}
     <a target="_blank" rel="noreferrer" href="{view_on_osm_link}">view on osm.org</a>
@@ -93,21 +90,28 @@
     <br>
     mouse position: {mouse_position}
   </div>
-  <div id="map-position-close"><a href="#hide" onclick={handleHideClick}>hide</a></div>
+  <div id="map-position-close"><a href="#hide" onclick={() => visible = false}>hide</a></div>
+{:else}
+<button class="btn btn-sm btn-outline-secondary" onclick={() => visible = true}
+>show map bounds</button>
+{/if}
 </div>
-
 
 <style>
   #map-position {
-    display: none;
+    display: block;
     position: absolute;
     top: 0;
     right: 20px;
-    padding: 0 5px;
     color: #333;
     font-size: 11px;
     background-color: rgba(255, 255, 255, 0.7);
     z-index: 1000;
+    margin: 5px
+  }
+
+  #map-position-inner {
+    padding: 0 5px;
   }
 
   #map-position-close {
@@ -120,4 +124,14 @@
       right: 20px;
     }
   }
+
+  .btn-outline-secondary {
+    background-color: white;
+  }
+
+  .btn-outline-secondary:hover {
+    color: #111;
+  }
+
+
 </style>

--- a/src/components/SearchSectionReverse.svelte
+++ b/src/components/SearchSectionReverse.svelte
@@ -1,29 +1,20 @@
 <script>
-  import { onDestroy } from 'svelte';
   import UrlSubmitForm from '../components/UrlSubmitForm.svelte';
-  import { SvelteURLSearchParams } from 'svelte/reactivity';
 
   import { zoomLevels } from '../lib/helpers.js';
-  import { map_store, refresh_page } from '../lib/stores.js';
+  import { refresh_page } from '../lib/stores.js';
+  import { mapState } from '../state/MapState.svelte.js';
 
   let { lat = '', lon = '', zoom = '', api_request_params = {} } = $props();
 
-  function gotoCoordinates(newlat, newlon, newzoom) {
-    if (newlat === null || newlon === null) return;
-
-    let params = new SvelteURLSearchParams();
-    params.set('lat', newlat);
-    params.set('lon', newlon);
-    params.set('zoom', newzoom || zoom);
-    refresh_page('reverse', params);
-  }
-
-  const unsubscribe = map_store.subscribe(map => {
-    if (map) {
-      map.on('click', (e) => {
-        let coords = e.latlng.wrap();
-        gotoCoordinates(coords.lat.toFixed(5), coords.lng.toFixed(5));
-      });
+  $effect(() => {
+    const newCenter = mapState.lastClick;
+    if (newCenter) {
+      refresh_page('reverse', new URLSearchParams({
+        'lat': newCenter.lat,
+        'lon': newCenter.lng,
+        'zoom': zoom
+      }));
     }
   });
 
@@ -43,10 +34,12 @@
   function onSwitchCoords(e) {
     e.preventDefault();
     e.stopPropagation();
-    gotoCoordinates(lon, lat);
+    refresh_page('reverse', new URLSearchParams({
+        lat: lon || '',
+        lon: lat || '',
+        zoom: zoom
+      }));
   }
-
-  onDestroy(unsubscribe);
 </script>
 
 {#snippet content()}

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store';
+import { untrack } from 'svelte';
 import { identifyLinkInQuery } from './helpers.js';
 
-export const map_store = writable();
 export const results_store = writable();
 export const last_api_request_url_store = writable();
 export const error_store = writable();
@@ -66,7 +66,9 @@ export function refresh_page(pagename, params) {
     }
   }
 
-  page.set({ tab: pagename, params: params });
-  last_api_request_url_store.set(null);
-  error_store.set(null);
+  untrack(() => {
+    page.set({ tab: pagename, params: params });
+    last_api_request_url_store.set(null);
+    error_store.set(null);
+  });
 }

--- a/src/pages/ReversePage.svelte
+++ b/src/pages/ReversePage.svelte
@@ -7,7 +7,7 @@
   import ResultsList from '../components/ResultsList.svelte';
   import Map from '../components/Map.svelte';
 
-  let api_request_params = $state();
+  let api_request_params = $state.raw();
   let current_result = $state();
   let position_marker = $state(); // what the user searched for
 
@@ -25,9 +25,9 @@
     };
 
     if (api_request_params.lat && api_request_params.lon) {
+      position_marker = [api_request_params.lat, api_request_params.lon];
 
       fetch_from_api('reverse', api_request_params, function (data) {
-        position_marker = [api_request_params.lat, api_request_params.lon];
         if (data && !data.error) {
           results_store.set([data]);
         } else {

--- a/src/state/MapState.svelte.js
+++ b/src/state/MapState.svelte.js
@@ -1,0 +1,12 @@
+import {latLng } from 'leaflet';
+
+class MapState {
+  center = $state(latLng(Nominatim_Config.Map_Default_Lat,
+                         Nominatim_Config.Map_Default_Lon));
+  zoom = $state(Nominatim_Config.Map_Default_Zoom);
+  viewboxStr = $state();
+  lastClick = $state();
+  mousePos = $state();
+}
+
+export const mapState = new MapState();

--- a/test/search.js
+++ b/test/search.js
@@ -35,10 +35,9 @@ describe('Search Page', function () {
     it('should show map bounds buttons', async function () {
       await page.waitForSelector('#map');
       let show_map_pos_handle = await page.$('#show-map-position');
-      let map_pos_handle = await page.$('#map-position');
+      assert.strictEqual(await page.$('#map-position-inner'), null);
 
       await show_map_pos_handle.click();
-      assert.strictEqual(await map_pos_handle.evaluate(node => node.style.display), 'block');
 
       let map_pos_details = await page.$eval('#map-position-inner', el => el.textContent);
       map_pos_details = map_pos_details.split('  ');
@@ -58,10 +57,11 @@ describe('Search Page', function () {
       assert.deepStrictEqual(map_center_coords.length, 2);
       assert.ok(map_zoom);
       assert.deepStrictEqual(map_viewbox.length, 4);
-      assert.deepStrictEqual(last_click, '65.62128,104.41406');
+      assert.deepStrictEqual(last_click, '-');
 
       await page.click('#map-position-close a');
-      assert.strictEqual(await map_pos_handle.evaluate(node => node.style.display), 'none');
+      assert.strictEqual(await page.$('#map-position-inner'), null);
+      assert.ok(await page.$('#show-map-position'));
     });
   });
 


### PR DESCRIPTION
This removes the global `map_store` and makes the Leaflet `map` object a private property of the `Map` component. It then exports various state information properties of the map via the new global `mapState`, implemented with Svelte runes.

Components needing any map state no longer need to register for map events themselves but can simply access the global map state. This massively simplifies the code.

The PR also slightly reorganises the code around MapPosition, moving the button that is visible when the position field is closed into the MapPosition component itself. This makes it easy to toggle the visibility through a singe boolean Svelte rune.