### PR TITLE
Do not keep map state when switching between search panes

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -94,8 +94,8 @@
             </li>
           {/if}
           <li class="nav-item">
-            <ReverseLink lat={mapState.center.lat}
-                         lon={mapState.center.lng}
+            <ReverseLink lat={mapState.center?.lat}
+                         lon={mapState.center?.lng}
                          text="Reverse"
                          extra_classes="nav-link {view === 'reverse' ? 'active' : ''}" />
           </li>

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -37,6 +37,12 @@
     ].join(',');
   }
 
+  function setMapState() {
+    mapState.viewboxStr = mapViewboxAsString(map);
+    mapState.center = map.getCenter();
+    mapState.zoom = map.getZoom();
+  }
+
   function createMap(container) {
     const attribution = Nominatim_Config.Map_Tile_Attribution;
 
@@ -44,8 +50,9 @@
       attributionControl: false,
       scrollWheelZoom: true, // !L.Browser.touch,
       touchZoom: false,
-      center: mapState.center,
-      zoom: mapState.zoom
+      center: L.latLng(Nominatim_Config.Map_Default_Lat,
+                       Nominatim_Config.Map_Default_Lon),
+      zoom: Nominatim_Config.Map_Default_Zoom
     });
     if (typeof Nominatim_Config.Map_Default_Bounds !== 'undefined'
       && Nominatim_Config.Map_Default_Bounds) {
@@ -56,7 +63,7 @@
       L.control.attribution({ prefix: '<a href="https://leafletjs.com/">Leaflet</a>' }).addTo(map);
     }
 
-    mapState.viewboxStr = mapViewboxAsString(map);
+    setMapState();
 
     L.control.scale().addTo(map);
 
@@ -73,12 +80,7 @@
       new L.Control.MiniMap(osm2, { toggleDisplay: true }).addTo(map);
     }
 
-    map.on('move', () => {
-      mapState.center = map.getCenter();
-      mapState.zoom = map.getZoom();
-      mapState.viewboxStr = mapViewboxAsString(map);
-    });
-
+    map.on('move', setMapState);
     map.on('mousemove', (e) => { mapState.mousePos = e.latlng; });
     map.on('click', (e) => { mapState.lastClick = e.latlng; });
   }
@@ -89,6 +91,7 @@
 
     return {
       destroy: () => {
+        mapState.reset();
         map.remove();
       }
     };

--- a/src/state/MapState.svelte.js
+++ b/src/state/MapState.svelte.js
@@ -1,12 +1,17 @@
-import {latLng } from 'leaflet';
-
 class MapState {
-  center = $state(latLng(Nominatim_Config.Map_Default_Lat,
-                         Nominatim_Config.Map_Default_Lon));
-  zoom = $state(Nominatim_Config.Map_Default_Zoom);
+  center = $state();
+  zoom = $state();
   viewboxStr = $state();
   lastClick = $state();
   mousePos = $state();
+
+  reset() {
+    this.center = undefined;
+    this.zoom = undefined;
+    this.viewboxStr = '';
+    this.lastClick = undefined;
+    this.mousePos = undefined;
+  }
 }
 
 export const mapState = new MapState();


### PR DESCRIPTION
Restores the behaviour the UI had before switching await from stores.

Note that this does not really fix the errors from the screen shots from https://github.com/osm-search/nominatim-ui/pull/292#issuecomment-3217453921. Those are already present in the current release version. This just makes them appear less often. Fix for errors follows.