### PR TITLE
more help text for postcode results which dont have a OSM id

### DIFF
--- a/src/components/DetailsPostcodeHint.svelte
+++ b/src/components/DetailsPostcodeHint.svelte
@@ -1,5 +1,5 @@
 <script>
-  let { postcode, lat, lon } = $props();
+  let { postcode, lat, lon, country_code } = $props();
 
   const overpass_query = $derived(`
     // Based on the map bounds, you can zoom out and rerun the query
@@ -67,6 +67,17 @@
     <a href="https://nominatim.org/2022/06/26/state-of-postcodes.html"
        target="_blank" rel="noreferrer">How Nominatim uses postcodes</a>.
   </p>
+  {#if country_code === 'gb'}
+    <p>
+      Additionally supplemented by Ordnance Survey Code-Point® Open data.
+      <a href="https://github.com/osm-search/gb-postcode-data" target="_blank">UK Postcode data for Nominatim</a>
+    </p>
+  {/if}
+  {#if country_code === 'us'}
+    <p>
+      Additionally supplemented by data derived from US Census (TIGER) data.
+    </p>
+  {/if}
 </div>
 
 <style>

--- a/src/pages/DetailsPage.svelte
+++ b/src/pages/DetailsPage.svelte
@@ -149,11 +149,12 @@
               </td></tr>
             {/if}
             <tr><td>Computed Postcode</td><td>
-              {#if aPlace.calculated_postcode}
-                {aPlace.calculated_postcode}
-                <DetailsPostcodeHint postcode={aPlace.calculated_postcode}
+              {#if aPlace.calculated_postcode || (aPlace.type === 'postcode' || !aPlace.osm_id)}
+                {aPlace.calculated_postcode || aPlace.names.ref}
+                <DetailsPostcodeHint postcode={aPlace.calculated_postcode || aPlace.names.ref}
                                      lat={aPlace.centroid.coordinates[1]}
-                                     lon={aPlace.centroid.coordinates[0]} />
+                                     lon={aPlace.centroid.coordinates[0]}
+                                     country_code={aPlace.country_code} />
               {/if}
             </td></tr>
             <tr><td>Address Tags</td><td>


### PR DESCRIPTION
fixes https://github.com/osm-search/nominatim-ui/issues/299

I used `20097, italia` as test postcode. And `W13 8PJ` for `gb`.