### PR TITLE
Fix typo in 'About & Help' text

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -131,7 +131,7 @@
         </li>
         <li class="nav-item">
           <PageLink page="about"
-                    text="Abount & Help"
+                    text="About & Help"
                     extra_classes="nav-link {view === 'about' ? 'active' : ''}" />
         </li>
       </ul>


### PR DESCRIPTION
This pull request contains a minor update to the navigation menu in the `Header.svelte` component, correcting a spelling error.

* Fixed the typo "Abount & Help" to "About & Help" in the navigation link text.