### PR TITLE
when no results and viewbox set, pan map to zoombox instead world

### DIFF
--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -160,6 +160,8 @@
       });
       map.addLayer(viewbox_on_map);
       dataLayers.push(viewbox_on_map);
+
+      if (!aFeature) map.fitBounds(bounds);
     }
 
     if (!aFeature) return;


### PR DESCRIPTION
fixes https://github.com/osm-search/nominatim-ui/issues/240

<img width="2616" height="1422" alt="image" src="https://github.com/user-attachments/assets/864444a4-f439-4635-a7a8-c00cc181a214" />