### PR TITLE
on status page allow admins to set a custom HTML message

### DIFF
--- a/dist/theme/status-help.html
+++ b/dist/theme/status-help.html
@@ -1,0 +1,7 @@
+<!--
+<div class="p-4">
+  The Nominatim service is run by administrator@example.com.
+
+  If you see connection failures first check <a href="http://example.com/status">the status page</a>.
+</div>
+ -->

--- a/src/pages/StatusPage.svelte
+++ b/src/pages/StatusPage.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import { update_html_title } from '../lib/api_utils.js';
+  import { update_html_title, fetch_content_into_element } from '../lib/api_utils.js';
   import { appState } from '../state/AppState.svelte.js';
 
   import Header from '../components/Header.svelte';
@@ -19,6 +19,10 @@
     update_html_title('Server status');
   }
   onMount(loaddata);
+
+  onMount(() => {
+    fetch_content_into_element('theme/status-help.html', document.getElementById('status-help'));
+  });
 </script>
 
 <Header/>
@@ -26,6 +30,8 @@
   <div class="row">
     <div class="col-sm-12">
       <h1>Server status</h1>
+
+      <div id="status-help" class="bg-secondary-subtle"></div>
 
       <dl>
         <dt>API Endpoint</dt>
@@ -43,3 +49,9 @@
     </div>
   </div>
 </div>
+
+<style>
+  #status-help {
+    margin: 2em 0;
+  }
+</style>


### PR DESCRIPTION
Allows admins to set a custom HTML message in their installation. Default is empty.

Fixes https://github.com/osm-search/nominatim-ui/issues/217

<img width="2238" height="1402" alt="image" src="https://github.com/user-attachments/assets/487e955e-a58c-4fde-bd54-90b4b376db7f" />
