### PR TITLE
tone down text color of form placeholder text

### DIFF
--- a/src/global_style.css
+++ b/src/global_style.css
@@ -9,6 +9,11 @@ a { text-decoration: none }
 a:hover { text-decoration: underline; }
 a.btn:hover { text-decoration: none; }
 
+.form-control::placeholder {
+  color: revert;
+  font-style: italic;
+}
+
 html[data-bs-theme=dark] img.mapicon {
   /* invert the image colors */
   filter: invert(1) hue-rotate(180deg);


### PR DESCRIPTION
Fixes https://github.com/osm-search/nominatim-ui/issues/211

<img width="1714" height="536" alt="image" src="https://github.com/user-attachments/assets/31affa91-5f79-4c65-aefd-49e4039420b3" />

<img width="1586" height="394" alt="image" src="https://github.com/user-attachments/assets/9210ec32-4096-4173-a040-c9acebde3c54" />
